### PR TITLE
feat(orchestration): add possibility to use a local version of the Python SDK

### DIFF
--- a/docs/LOCAL_SENTRY_SDK.md
+++ b/docs/LOCAL_SENTRY_SDK.md
@@ -1,78 +1,160 @@
 # Using Local Sentry SDK for Development
 
-This guide explains how to use a local copy of the Sentry Python SDK when running tests, instead of installing from PyPI. This is useful when you're developing changes to the Sentry SDK and want to test them against AI SDK integrations.
+This guide explains how to use a local copy of the Sentry SDK (Python or JavaScript) when running tests, instead of installing from package repositories. This is useful when you're developing changes to the Sentry SDK and want to test them against AI SDK integrations.
 
 ## Quick Start
+
+### Python SDK
 
 If you have the Sentry Python SDK cloned adjacent to this repository:
 
 ```bash
 # Setup all Python SDKs with local Sentry SDK
 cd shared/orchestration
-npm run cli setup -- --local-sentry-sdk ../../../sentry-python
+npm run cli setup -- --local-sentry-python ../../../sentry-python
 
 # Run tests with local Sentry SDK
-npm run cli run -- --all --local-sentry-sdk ../../../sentry-python
+npm run cli run -- --all --local-sentry-python ../../../sentry-python
+```
+
+### JavaScript SDK
+
+If you have the Sentry JavaScript SDK cloned adjacent to this repository:
+
+```bash
+# Setup all JavaScript SDKs with local Sentry SDK
+cd shared/orchestration
+npm run cli setup -- --local-sentry-javascript ../../../sentry-javascript
+
+# Run tests with local Sentry SDK
+npm run cli run -- --all --local-sentry-javascript ../../../sentry-javascript
+```
+
+### Both SDKs
+
+You can use both flags simultaneously to test with local versions of both SDKs:
+
+```bash
+# Setup with both local SDKs
+npm run cli setup -- --local-sentry-python ../../../sentry-python --local-sentry-javascript ../../../sentry-javascript
+
+# Run tests with both local SDKs
+npm run cli run -- --all --local-sentry-python ../../../sentry-python --local-sentry-javascript ../../../sentry-javascript
 ```
 
 ## How It Works
 
 When you use the `--local-sentry-sdk` flag:
 
+### Python SDKs
+
 1. The orchestrator validates the provided path
 2. For each Python SDK, it:
    - Installs the local Sentry SDK as editable: `pip install -e /path/to/sentry-python`
-   - Installs other dependencies from `requirements.txt`
+   - Installs other dependencies from `requirements.txt` (excluding sentry-sdk)
 3. Tests run with your local Sentry SDK code
 4. Changes to the Sentry SDK source are immediately reflected (no reinstall needed)
 
 **Important:** Your `requirements.txt` files remain unmodified, keeping git status clean.
 
+### JavaScript SDKs
+
+1. The orchestrator validates the provided path (must be sentry-javascript monorepo)
+2. For each JavaScript SDK, it:
+   - Reads `package.json` to find which `@sentry/*` packages are used
+   - Links each package: `npm link /path/to/sentry-javascript/packages/node`
+   - Installs other dependencies normally
+3. Tests run with your local Sentry SDK code
+4. Changes to the Sentry SDK source are immediately reflected (no rebuild needed)
+
+**Important:** Your `package.json` files remain unmodified, keeping git status clean.
+
 ## Setup Command
 
-Install all dependencies with a local Sentry SDK:
+Install all dependencies with local Sentry SDKs:
 
 ```bash
-npm run cli setup -- --local-sentry-sdk <path>
+# For Python SDK
+npm run cli setup -- --local-sentry-python <path>
+
+# For JavaScript SDK
+npm run cli setup -- --local-sentry-javascript <path>
+
+# For both
+npm run cli setup -- --local-sentry-python <path> --local-sentry-javascript <path>
 ```
 
-**Path requirements:**
+### Path Requirements
+
+**For Python SDK (`sentry-python`):**
 - Can be relative (e.g., `../sentry-python`) or absolute
 - Must point to the Sentry Python SDK repository root
 - Must contain:
   - `setup.py` (valid Python package)
   - `sentry_sdk/` directory (the actual package)
 
-**Example:**
-```bash
-# Relative path (adjacent to repo)
-npm run cli setup -- --local-sentry-sdk ../sentry-python
+**For JavaScript SDK (`sentry-javascript`):**
+- Can be relative (e.g., `../sentry-javascript`) or absolute
+- Must point to the Sentry JavaScript SDK monorepo root
+- Must contain:
+  - `packages/` directory (monorepo structure)
+  - Root `package.json` (workspace configuration)
 
-# Absolute path
-npm run cli setup -- --local-sentry-sdk /Users/username/dev/sentry-python
+### Examples
+
+```bash
+# Python SDK - Relative path (adjacent to repo)
+npm run cli setup -- --local-sentry-python ../sentry-python
+
+# Python SDK - Absolute path
+npm run cli setup -- --local-sentry-python /Users/username/dev/sentry-python
+
+# JavaScript SDK - Relative path (adjacent to repo)
+npm run cli setup -- --local-sentry-javascript ../sentry-javascript
+
+# JavaScript SDK - Absolute path
+npm run cli setup -- --local-sentry-javascript /Users/username/dev/sentry-javascript
 ```
 
 ## Run Command
 
-Run tests with a local Sentry SDK:
+Run tests with local Sentry SDKs:
 
 ```bash
-npm run cli run [filter] -- --local-sentry-sdk <path>
+# For Python SDK
+npm run cli run [filter] -- --local-sentry-python <path>
+
+# For JavaScript SDK
+npm run cli run [filter] -- --local-sentry-javascript <path>
+
+# For both
+npm run cli run [filter] -- --local-sentry-python <path> --local-sentry-javascript <path>
 ```
 
 **Examples:**
 ```bash
-# Run all tests with local SDK
-npm run cli run -- --all --local-sentry-sdk ../sentry-python
+# Run all tests with local Python SDK
+npm run cli run -- --all --local-sentry-python ../sentry-python
 
-# Run specific SDK with local Sentry
-npm run cli run py/openai -- --local-sentry-sdk ../sentry-python
+# Run all tests with local JavaScript SDK
+npm run cli run -- --all --local-sentry-javascript ../sentry-javascript
 
-# Run specific test case with local Sentry
-npm run cli run -- --case 1-simple --local-sentry-sdk ../sentry-python
+# Run all tests with both local SDKs
+npm run cli run -- --all --local-sentry-python ../sentry-python --local-sentry-javascript ../sentry-javascript
+
+# Run specific Python SDK with local Sentry
+npm run cli run py/openai -- --local-sentry-python ../sentry-python
+
+# Run specific JavaScript SDK with local Sentry
+npm run cli run js/openai -- --local-sentry-javascript ../sentry-javascript
+
+# Run specific test case with local Python SDK
+npm run cli run -- --case 1-simple --local-sentry-python ../sentry-python
 ```
 
-## Verifying Editable Install
+## Verifying Local Installs
+
+### Python SDK (Editable Install)
 
 Check if the editable install is active:
 
@@ -92,9 +174,38 @@ sentry-sdk           2.43.0    /path/to/sentry-python
 sentry-sdk           2.43.0
 ```
 
-## Reverting to PyPI Version
+### JavaScript SDK (npm link)
 
-To switch back to the PyPI version of Sentry SDK:
+Check if npm link is active:
+
+```bash
+# From any JavaScript SDK directory
+cd sdks/js/openai
+ls -la node_modules/@sentry/node
+```
+
+**Expected output (linked):**
+```
+lrwxr-xr-x  ... node_modules/@sentry/node -> /path/to/sentry-javascript/packages/node
+```
+
+**Expected output (npm registry):**
+```
+drwxr-xr-x  ... node_modules/@sentry/node
+```
+
+Or use npm to check:
+
+```bash
+npm ls @sentry/node
+# Linked shows: @sentry/node@X.Y.Z -> /path/to/sentry-javascript/packages/node
+```
+
+## Reverting to Package Registry Versions
+
+### Python SDK
+
+To switch back to the PyPI version:
 
 ```bash
 # Option 1: Uninstall editable, then setup normally
@@ -110,9 +221,29 @@ cd ../../../shared/orchestration
 npm run cli setup
 ```
 
-## Upgrading Packages with Editable Installs
+### JavaScript SDK
 
-The upgrade command protects you from accidentally overwriting editable installs:
+To switch back to the npm registry version:
+
+```bash
+# Option 1: Unlink specific package, then setup normally
+cd sdks/js/openai
+npm unlink @sentry/node
+cd ../../../shared/orchestration
+npm run cli setup
+
+# Option 2: Delete node_modules and recreate
+cd sdks/js/openai
+rm -rf node_modules package-lock.json
+cd ../../../shared/orchestration
+npm run cli setup
+```
+
+## Upgrading Packages with Local Installs
+
+The upgrade command protects you from accidentally overwriting local installs.
+
+### Python SDK Example
 
 ```bash
 npm run cli upgrade sentry-sdk 2.50.0
@@ -126,14 +257,32 @@ npm run cli upgrade sentry-sdk 2.50.0
     Then run: npm run cli setup
 ```
 
+### JavaScript SDK Example
+
+```bash
+npm run cli upgrade @sentry/node 8.50.0
+```
+
+**Output when npm link is active:**
+```
+  js/openai - Skipping (npm linked)
+    To upgrade, first unlink:
+    cd sdks/js/openai && npm unlink @sentry/node
+    Then run: npm run cli setup
+```
+
+### Behavior
+
 The upgrade command will:
-- Skip all SDKs with editable Sentry SDK installs
-- Show clear instructions on how to remove the editable install
+- Skip all SDKs with local Sentry SDK installs (editable or linked)
+- Show clear instructions on how to remove the local install
 - Continue upgrading other packages normally
 
 ## Troubleshooting
 
-### Error: Local Sentry SDK path does not exist
+### Python SDK Errors
+
+#### Error: Local Sentry SDK path does not exist
 
 **Problem:** The path you provided doesn't exist.
 
@@ -142,7 +291,7 @@ The upgrade command will:
 ls ../sentry-python  # Should show the repository contents
 ```
 
-### Error: Local Sentry SDK path is not a directory
+#### Error: Local Sentry SDK path is not a directory
 
 **Problem:** The path points to a file, not a directory.
 
@@ -155,7 +304,7 @@ ls ../sentry-python  # Should show the repository contents
 --local-sentry-sdk ../sentry-python
 ```
 
-### Error: Local Sentry SDK path missing setup.py
+#### Error: Local Sentry SDK path missing setup.py
 
 **Problem:** The directory isn't a valid Python package.
 
@@ -164,7 +313,7 @@ ls ../sentry-python  # Should show the repository contents
 ls ../sentry-python/setup.py  # Should exist
 ```
 
-### Error: Local Sentry SDK path missing sentry_sdk/ directory
+#### Error: Local Sentry SDK path missing sentry_sdk/ directory
 
 **Problem:** The package doesn't contain the sentry_sdk module.
 
@@ -173,11 +322,48 @@ ls ../sentry-python/setup.py  # Should exist
 ls ../sentry-python/sentry_sdk/  # Should show the package
 ```
 
-### Tests fail after switching to local SDK
+### JavaScript SDK Errors
+
+#### Error: Local Sentry JavaScript SDK path missing packages/ directory
+
+**Problem:** The path doesn't point to the sentry-javascript monorepo.
+
+**Solution:** Ensure you're pointing to the monorepo root:
+```bash
+ls ../sentry-javascript/packages/  # Should show all @sentry/* packages
+```
+
+#### Error: Local Sentry JavaScript SDK path missing root package.json
+
+**Problem:** The directory isn't a valid npm workspace/monorepo.
+
+**Solution:** Verify the monorepo structure:
+```bash
+ls ../sentry-javascript/package.json  # Should exist
+cat ../sentry-javascript/package.json | grep workspaces  # Should have workspaces
+```
+
+#### Warning: Package not found in local SDK, using npm
+
+**Problem:** The JavaScript SDK doesn't have a specific package you're trying to link.
+
+**Solution:** This is informational - the orchestrator will fall back to npm for that package. This can happen with:
+- New or experimental packages not yet in your local SDK
+- Renamed packages
+- Packages from other scopes
+
+```bash
+# Verify which packages exist in your local SDK
+ls ../sentry-javascript/packages/
+```
+
+### General Issues
+
+#### Tests fail after switching to local SDK
 
 **Problem:** Your local Sentry SDK has breaking changes or bugs.
 
-**Solution:**
+**Solution for Python:**
 1. Check your local Sentry SDK changes
 2. Revert to PyPI version to confirm tests pass:
    ```bash
@@ -186,19 +372,30 @@ ls ../sentry-python/sentry_sdk/  # Should show the package
    .venv/bin/pip install sentry-sdk==2.43.0
    ```
 
+**Solution for JavaScript:**
+1. Check your local Sentry SDK changes
+2. Revert to npm registry version to confirm tests pass:
+   ```bash
+   cd sdks/js/openai
+   npm unlink @sentry/node
+   npm install @sentry/node@8.0.0
+   ```
+
 ## Common Workflows
 
 ### Developing a Sentry SDK Feature
 
+**Python:**
+
 ```bash
 # 1. Setup with local SDK
-npm run cli setup -- --local-sentry-sdk ../sentry-python
+npm run cli setup -- --local-sentry-python ../sentry-python
 
 # 2. Make changes to sentry-python code
 # (edit files in ../sentry-python/)
 
 # 3. Run tests (changes are automatically picked up)
-npm run cli run -- --all
+npm run cli run -- --all --local-sentry-python ../sentry-python
 
 # 4. When done, revert to PyPI version
 for sdk in sdks/py/*/; do
@@ -209,7 +406,34 @@ for sdk in sdks/py/*/; do
 done
 ```
 
+**JavaScript:**
+
+```bash
+# 1. Setup with local SDK
+npm run cli setup -- --local-sentry-javascript ../sentry-javascript
+
+# 2. Make changes to sentry-javascript code
+# (edit files in ../sentry-javascript/packages/*)
+
+# 3. Run tests (changes are automatically picked up)
+npm run cli run -- --all --local-sentry-javascript ../sentry-javascript
+
+# 4. When done, revert to npm registry version
+for sdk in sdks/js/*/; do
+  cd "$sdk"
+  for pkg in node_modules/@sentry/*; do
+    if [ -L "$pkg" ]; then
+      npm unlink "$(basename $(dirname $pkg))/$(basename $pkg)"
+    fi
+  done
+  npm install
+  cd -
+done
+```
+
 ### Testing a Specific Sentry SDK Branch
+
+**Python:**
 
 ```bash
 # 1. Clone and checkout branch
@@ -220,10 +444,30 @@ git checkout feature/my-new-integration
 
 # 2. Setup tests with this branch
 cd ../testing-ai-sdk-integrations/shared/orchestration
-npm run cli setup -- --local-sentry-sdk ../sentry-python
+npm run cli setup -- --local-sentry-python ../sentry-python
 
 # 3. Run tests
-npm run cli run -- --all
+npm run cli run -- --all --local-sentry-python ../sentry-python
+```
+
+**JavaScript:**
+
+```bash
+# 1. Clone and checkout branch
+cd ..
+git clone https://github.com/getsentry/sentry-javascript.git
+cd sentry-javascript
+git checkout feature/my-new-integration
+
+# 2. Build the SDK (important for JavaScript!)
+npm install && npm run build
+
+# 3. Setup tests with this branch
+cd ../testing-ai-sdk-integrations/shared/orchestration
+npm run cli setup -- --local-sentry-javascript ../sentry-javascript
+
+# 4. Run tests
+npm run cli run -- --all --local-sentry-javascript ../sentry-javascript
 ```
 
 ### Multiple Developers with Different SDK Locations
@@ -231,38 +475,60 @@ npm run cli run -- --all
 Each developer can use their own path without affecting others:
 
 ```bash
-# Developer A (macOS)
-npm run cli setup -- --local-sentry-sdk /Users/alice/dev/sentry-python
+# Developer A (macOS) - Python SDK
+npm run cli setup -- --local-sentry-python /Users/alice/dev/sentry-python
 
-# Developer B (Linux)
-npm run cli setup -- --local-sentry-sdk /home/bob/projects/sentry-python
+# Developer B (Linux) - Python SDK
+npm run cli setup -- --local-sentry-python /home/bob/projects/sentry-python
 
-# Developer C (Windows)
-npm run cli setup -- --local-sentry-sdk C:/dev/sentry-python
+# Developer C (Windows) - JavaScript SDK
+npm run cli setup -- --local-sentry-javascript C:/dev/sentry-javascript
+
+# Developer D - Both SDKs
+npm run cli setup -- --local-sentry-python ../sentry-python --local-sentry-javascript ../sentry-javascript
 ```
 
-The `requirements.txt` files are never modified, so there are no git conflicts.
+The `requirements.txt` and `package.json` files are never modified, so there are no git conflicts.
 
 ## Technical Details
 
-### Why Editable Installs?
+### Python: Why Editable Installs?
 
 Editable installs (`pip install -e`) create a link to your local code instead of copying files to `site-packages`. This means:
 - ✅ Changes to Sentry SDK source are immediately reflected
 - ✅ No need to reinstall after each change
 - ✅ Easy to develop and test simultaneously
 
-### Where Are Editable Installs Stored?
+**Where Are Editable Installs Stored?**
 
 Editable install metadata is stored in:
 - `.venv/lib/python3.x/site-packages/sentry-sdk.egg-link` (points to your local path)
 - `.venv/lib/python3.x/site-packages/__editable__.sentry_sdk-*.pth`
 
+### JavaScript: Why npm link?
+
+npm link creates symbolic links in `node_modules` to your local code. This means:
+- ✅ Changes to Sentry SDK source are immediately reflected (if already built)
+- ✅ Works with TypeScript source maps for debugging
+- ✅ Preserves monorepo structure
+
+**Where Are Links Stored?**
+
+npm link creates symlinks in:
+- `node_modules/@sentry/node` → `/path/to/sentry-javascript/packages/node`
+- `node_modules/@sentry/core` → `/path/to/sentry-javascript/packages/core`
+- etc.
+
+**Important Note:** For TypeScript changes in sentry-javascript, you may need to rebuild:
+```bash
+cd ../sentry-javascript && npm run build
+```
+
 ### Impact on CI/Production
 
-**Zero impact** - editable installs only affect your local development environment:
-- `requirements.txt` files remain unchanged
-- CI always installs from PyPI (exact versions)
+**Zero impact** - local installs only affect your local development environment:
+- `requirements.txt` and `package.json` files remain unchanged
+- CI always installs from PyPI/npm (exact versions)
 - Other developers unaffected unless they use the flag
 
 ## Best Practices

--- a/shared/orchestration/src/cli.ts
+++ b/shared/orchestration/src/cli.ts
@@ -103,7 +103,8 @@ program
     'Generate reports (comma-separated: ctrf,html or "all")',
     "all"
   )
-  .option("--local-sentry-sdk <path>", "Use local Sentry SDK for editable install (Python SDKs)")
+  .option("--local-sentry-python <path>", "Use local Sentry Python SDK (sentry-python)")
+  .option("--local-sentry-javascript <path>", "Use local Sentry JavaScript SDK (sentry-javascript)")
   .action(async (filter, options) => {
     // Validate options
     if (!filter && !options.case && !options.all) {
@@ -173,7 +174,10 @@ program
 
     // Run tests
     const startTime = Date.now();
-    const results = await runTests(sdks, { localSentrySdkPath: options.localSentrySdk });
+    const results = await runTests(sdks, {
+      localSentryPythonPath: options.localSentryPython,
+      localSentryJavaScriptPath: options.localSentryJavascript
+    });
     const duration = Date.now() - startTime;
 
     // Generate CTRF report (single source of truth)
@@ -219,9 +223,13 @@ program
 program
   .command("setup")
   .description("Install all dependencies across the repository")
-  .option("--local-sentry-sdk <path>", "Use local Sentry SDK for editable install (Python SDKs)")
+  .option("--local-sentry-python <path>", "Use local Sentry Python SDK (sentry-python)")
+  .option("--local-sentry-javascript <path>", "Use local Sentry JavaScript SDK (sentry-javascript)")
   .action(async (options) => {
-    await setup({ localSentrySdkPath: options.localSentrySdk });
+    await setup({
+      localSentryPythonPath: options.localSentryPython,
+      localSentryJavaScriptPath: options.localSentryJavascript
+    });
   });
 
 /**

--- a/shared/orchestration/src/runner.ts
+++ b/shared/orchestration/src/runner.ts
@@ -169,9 +169,12 @@ function runPythonTest(filePath: string, caseId: string, config?: SDKConfig, sdk
       env.SDK_CONFIG_OVERRIDES = JSON.stringify(config.overrides[caseId]);
     }
 
-    // Pass local Sentry SDK path (for informational purposes)
-    if (options?.localSentrySdkPath) {
-      env.LOCAL_SENTRY_SDK_PATH = options.localSentrySdkPath;
+    // Pass local Sentry SDK paths (for informational purposes)
+    if (options?.localSentryPythonPath) {
+      env.LOCAL_SENTRY_PYTHON_PATH = options.localSentryPythonPath;
+    }
+    if (options?.localSentryJavaScriptPath) {
+      env.LOCAL_SENTRY_JAVASCRIPT_PATH = options.localSentryJavaScriptPath;
     }
 
     // Check if verbose mode is enabled

--- a/shared/orchestration/src/setup.ts
+++ b/shared/orchestration/src/setup.ts
@@ -18,7 +18,7 @@ interface SetupResult {
 }
 
 /**
- * Validate local Sentry SDK path
+ * Validate local Sentry Python SDK path
  */
 function validateLocalSentrySdkPath(path: string): void {
   const absolutePath = resolve(path);
@@ -59,6 +59,52 @@ function validateLocalSentrySdkPath(path: string): void {
       chalk.red(`✗ Local Sentry SDK path missing sentry_sdk/ directory: ${path}`) +
       '\n' +
       chalk.gray('  Path must contain the sentry_sdk package.')
+    );
+  }
+}
+
+/**
+ * Validate local Sentry JavaScript SDK path
+ */
+function validateLocalSentryJsSdkPath(path: string): void {
+  const absolutePath = resolve(path);
+
+  // Check if path exists
+  if (!existsSync(absolutePath)) {
+    throw new Error(
+      chalk.red(`✗ Local Sentry JavaScript SDK path does not exist: ${path}`) +
+      '\n' +
+      chalk.gray('  Check the path and try again.')
+    );
+  }
+
+  // Check if it's a directory
+  const stats = statSync(absolutePath);
+  if (!stats.isDirectory()) {
+    throw new Error(
+      chalk.red(`✗ Local Sentry JavaScript SDK path is not a directory: ${path}`) +
+      '\n' +
+      chalk.gray('  Path must point to the repository root directory.')
+    );
+  }
+
+  // Check if packages/ directory exists (monorepo structure)
+  const packagesDir = join(absolutePath, 'packages');
+  if (!existsSync(packagesDir) || !statSync(packagesDir).isDirectory()) {
+    throw new Error(
+      chalk.red(`✗ Local Sentry JavaScript SDK path missing packages/ directory: ${path}`) +
+      '\n' +
+      chalk.gray('  Path must be the sentry-javascript monorepo with packages/ directory.')
+    );
+  }
+
+  // Check if package.json exists at root (monorepo root)
+  const rootPackageJson = join(absolutePath, 'package.json');
+  if (!existsSync(rootPackageJson)) {
+    throw new Error(
+      chalk.red(`✗ Local Sentry JavaScript SDK path missing root package.json: ${path}`) +
+      '\n' +
+      chalk.gray('  Path must be a valid npm workspace/monorepo.')
     );
   }
 }
@@ -127,17 +173,69 @@ async function setupOrchestration(): Promise<SetupResult> {
 /**
  * Setup a JavaScript SDK
  */
-async function setupJavaScriptSDK(sdkPath: string, absolutePath: string): Promise<SetupResult> {
+async function setupJavaScriptSDK(sdkPath: string, absolutePath: string, options?: LocalSentryOptions): Promise<SetupResult> {
   try {
-    process.stdout.write(chalk.gray(`  ${sdkPath} - Installing dependencies...`));
-    await runCommand('npm', ['install'], absolutePath);
-    process.stdout.write(chalk.green(' ✓\n'));
+    // If local Sentry JavaScript SDK path is provided, link it
+    if (options?.localSentryJavaScriptPath) {
+      const absoluteLocalPath = resolve(options.localSentryJavaScriptPath);
+      validateLocalSentryJsSdkPath(absoluteLocalPath);
 
-    return {
-      success: true,
-      sdkPath,
-      step: 'npm install'
-    };
+      // Read package.json to find which @sentry/* packages are used
+      const packageJsonPath = join(absolutePath, 'package.json');
+      const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+      const sentryPackages = Object.keys(packageJson.dependencies || {})
+        .filter(pkg => pkg.startsWith('@sentry/'));
+
+      if (sentryPackages.length === 0) {
+        process.stdout.write(chalk.yellow(`  ${sdkPath} - No @sentry/* packages found, skipping\n`));
+        return {
+          success: true,
+          sdkPath,
+          step: 'npm install (no sentry packages)'
+        };
+      }
+
+      // Link each Sentry package from the local SDK
+      for (const sentryPkg of sentryPackages) {
+        process.stdout.write(chalk.gray(`  ${sdkPath} - Linking ${sentryPkg}...`));
+
+        // Get the package name without scope (e.g., @sentry/node -> node)
+        const packageName = sentryPkg.split('/')[1];
+        const packagePath = join(absoluteLocalPath, 'packages', packageName);
+
+        // Check if package exists in local SDK
+        if (!existsSync(packagePath)) {
+          process.stdout.write(chalk.yellow(` (not found in local SDK, using npm)\n`));
+          continue;
+        }
+
+        // Link the package: npm link /path/to/sentry-javascript/packages/node
+        await runCommand('npm', ['link', packagePath], absolutePath);
+        process.stdout.write(chalk.green(' ✓\n'));
+      }
+
+      // Install other dependencies
+      process.stdout.write(chalk.gray(`  ${sdkPath} - Installing other dependencies...`));
+      await runCommand('npm', ['install'], absolutePath);
+      process.stdout.write(chalk.green(' ✓\n'));
+
+      return {
+        success: true,
+        sdkPath,
+        step: 'npm install (linked)'
+      };
+    } else {
+      // Standard install
+      process.stdout.write(chalk.gray(`  ${sdkPath} - Installing dependencies...`));
+      await runCommand('npm', ['install'], absolutePath);
+      process.stdout.write(chalk.green(' ✓\n'));
+
+      return {
+        success: true,
+        sdkPath,
+        step: 'npm install'
+      };
+    }
   } catch (error) {
     process.stdout.write(chalk.red(' ✗\n'));
     return {
@@ -192,9 +290,9 @@ async function setupPythonSDK(sdkPath: string, absolutePath: string, options?: L
     const pipPath = join(venvPath, 'bin', 'pip');
 
     // If local Sentry SDK path is provided, install it as editable
-    if (options?.localSentrySdkPath) {
+    if (options?.localSentryPythonPath) {
       // Validate the local path
-      const absoluteLocalPath = resolve(options.localSentrySdkPath);
+      const absoluteLocalPath = resolve(options.localSentryPythonPath);
       validateLocalSentrySdkPath(absoluteLocalPath);
 
       // Install editable Sentry SDK first
@@ -273,7 +371,7 @@ export async function setup(options?: SetupOptions): Promise<void> {
   if (jsSDKs.length > 0) {
     console.log(chalk.bold('JavaScript SDKs'));
     for (const sdk of jsSDKs) {
-      const result = await setupJavaScriptSDK(sdk.path, sdk.absolutePath);
+      const result = await setupJavaScriptSDK(sdk.path, sdk.absolutePath, options);
       allResults.push(result);
     }
     console.log('');

--- a/shared/orchestration/src/types.ts
+++ b/shared/orchestration/src/types.ts
@@ -41,7 +41,8 @@ export interface TestCaseModule {
 }
 
 export interface LocalSentryOptions {
-  localSentrySdkPath?: string;  // Path to local Sentry SDK for editable install
+  localSentryPythonPath?: string;     // Path to local Sentry Python SDK (sentry-python)
+  localSentryJavaScriptPath?: string; // Path to local Sentry JavaScript SDK (sentry-javascript)
 }
 
 export interface SetupOptions extends LocalSentryOptions {

--- a/shared/orchestration/src/upgrade.ts
+++ b/shared/orchestration/src/upgrade.ts
@@ -3,7 +3,7 @@
  */
 
 import { spawn } from 'child_process';
-import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, lstatSync } from 'fs';
 import { join } from 'path';
 import chalk from 'chalk';
 import { discoverSDKs } from './discovery.js';
@@ -162,6 +162,27 @@ function updatePackageJson(filePath: string, packageName: string, version: strin
 }
 
 /**
+ * Check if a package is linked using npm link
+ */
+function isNpmLinked(sdkPath: string, packageName: string): boolean {
+  try {
+    const nodeModulesPath = join(sdkPath, 'node_modules', packageName);
+
+    // Check if the package exists in node_modules
+    if (!existsSync(nodeModulesPath)) {
+      return false;
+    }
+
+    // Check if it's a symlink (npm link creates symlinks)
+    const stats = lstatSync(nodeModulesPath);
+    return stats.isSymbolicLink();
+  } catch (error) {
+    // If we can't determine, assume it's not linked
+    return false;
+  }
+}
+
+/**
  * Check if a package is installed as editable in a Python venv
  */
 async function isEditableInstall(venvPath: string, packageName: string): Promise<boolean> {
@@ -270,6 +291,16 @@ async function upgradeJavaScriptSDKs(packageName: string, version: string): Prom
     const packageJsonPath = join(sdk.absolutePath, 'package.json');
 
     if (!existsSync(packageJsonPath)) {
+      continue;
+    }
+
+    // Check if package is linked via npm link
+    const isLinked = isNpmLinked(sdk.absolutePath, packageName);
+    if (isLinked) {
+      process.stdout.write(chalk.yellow(`  ${sdk.path} - Skipping (npm linked)\n`));
+      process.stdout.write(chalk.gray(`    To upgrade, first unlink:\n`));
+      process.stdout.write(chalk.gray(`    cd ${sdk.path} && npm unlink ${packageName}\n`));
+      process.stdout.write(chalk.gray(`    Then run: npm run cli setup\n`));
       continue;
     }
 


### PR DESCRIPTION
Totally vibecoded!

Closes https://linear.app/getsentry/issue/TET-1515/ai-testing-framework-allow-using-a-local-python-sdk