### PR TITLE
feat(action)!: Add language scoped setups

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,8 +8,9 @@ branding:
 
 inputs:
   language:
-    description: "SDK language to test. One of: js, python"
-    required: true
+    description: "SDK language to test. One of: js, py, or leave empty for both"
+    required: false
+    default: ""
   openai-api-key:
     description: "OpenAI API key"
     required: true
@@ -34,6 +35,7 @@ runs:
         node-version: "20"
 
     - name: Setup Python
+      if: inputs.language == 'py' || inputs.language == ''
       uses: actions/setup-python@v5
       with:
         python-version: "3.13"
@@ -46,7 +48,12 @@ runs:
     - name: Setup SDK dependencies
       shell: bash
       working-directory: ${{ github.action_path }}
-      run: npm run cli setup
+      run: |
+        if [ -z "${{ inputs.language }}" ]; then
+          npm run cli setup
+        else
+          npm run cli setup ${{ inputs.language }}
+        fi
 
     - name: Run tests
       id: run-tests
@@ -58,7 +65,11 @@ runs:
         GOOGLE_API_KEY: ${{ inputs.google-api-key }}
       run: |
         set +e
-        npm run cli run ${{ inputs.language }} --reports ctrf
+        if [ -z "${{ inputs.language }}" ]; then
+          npm run cli run -- --all --reports ctrf
+        else
+          npm run cli run ${{ inputs.language }} -- --reports ctrf
+        fi
         EXIT_CODE=$?
         set -e
 
@@ -77,7 +88,8 @@ runs:
         script: |
           const fs = require('fs');
           const path = require('path');
-          const language = '${{ inputs.language }}';
+          const language = '${{ inputs.language }}' || 'all';
+          const languageDisplay = language === 'all' ? 'js & py' : language;
           const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
           // Try to read test results from CTRF report
@@ -98,7 +110,7 @@ runs:
 
           const body = `## AI Integration Test Failure
 
-          **Language**: ${language}
+          **Language**: ${languageDisplay}
           **Date**: ${new Date().toISOString()}
           **Workflow Run**: ${runUrl}
 
@@ -130,7 +142,7 @@ runs:
             const newIssue = await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `AI Integration Tests Failed (${language}) - ${today}`,
+              title: `AI Integration Tests Failed (${languageDisplay}) - ${today}`,
               body: body,
               labels: [issueLabel, 'automated']
             });

--- a/shared/orchestration/src/cli.ts
+++ b/shared/orchestration/src/cli.ts
@@ -221,12 +221,23 @@ program
  * Setup command - Install all dependencies
  */
 program
-  .command("setup")
-  .description("Install all dependencies across the repository")
+  .command("setup [language]")
+  .description("Install all dependencies across the repository (optionally filter by 'js' or 'py')")
   .option("--local-sentry-python <path>", "Use local Sentry Python SDK (sentry-python)")
   .option("--local-sentry-javascript <path>", "Use local Sentry JavaScript SDK (sentry-javascript)")
-  .action(async (options) => {
+  .action(async (language, options) => {
+    // Validate language argument if provided
+    if (language && language !== 'js' && language !== 'py') {
+      console.log(chalk.red(`Error: Invalid language "${language}". Must be "js" or "py".`));
+      console.log(chalk.gray('Examples:'));
+      console.log(chalk.gray('  npm run cli setup        (all SDKs)'));
+      console.log(chalk.gray('  npm run cli setup js     (JS only)'));
+      console.log(chalk.gray('  npm run cli setup py     (Python only)'));
+      process.exit(1);
+    }
+
     await setup({
+      language: language as 'js' | 'py' | undefined,
       localSentryPythonPath: options.localSentryPython,
       localSentryJavaScriptPath: options.localSentryJavascript
     });

--- a/shared/orchestration/src/setup.ts
+++ b/shared/orchestration/src/setup.ts
@@ -349,6 +349,13 @@ async function setupPythonSDK(sdkPath: string, absolutePath: string, options?: L
 }
 
 /**
+ * Check if we should setup SDKs for a given language
+ */
+function shouldSetupLanguage(language: 'js' | 'py', options?: SetupOptions): boolean {
+  return !options?.language || options.language === language;
+}
+
+/**
  * Main setup function
  */
 export async function setup(options?: SetupOptions): Promise<void> {
@@ -368,7 +375,7 @@ export async function setup(options?: SetupOptions): Promise<void> {
   const pySDKs = sdks.filter(sdk => sdk.language === 'py');
 
   // Setup JavaScript SDKs
-  if (jsSDKs.length > 0) {
+  if (shouldSetupLanguage('js', options) && jsSDKs.length > 0) {
     console.log(chalk.bold('JavaScript SDKs'));
     for (const sdk of jsSDKs) {
       const result = await setupJavaScriptSDK(sdk.path, sdk.absolutePath, options);
@@ -378,7 +385,7 @@ export async function setup(options?: SetupOptions): Promise<void> {
   }
 
   // Setup Python SDKs
-  if (pySDKs.length > 0) {
+  if (shouldSetupLanguage('py', options) && pySDKs.length > 0) {
     console.log(chalk.bold('Python SDKs'));
     for (const sdk of pySDKs) {
       const results = await setupPythonSDK(sdk.path, sdk.absolutePath, options);

--- a/shared/orchestration/src/types.ts
+++ b/shared/orchestration/src/types.ts
@@ -46,7 +46,7 @@ export interface LocalSentryOptions {
 }
 
 export interface SetupOptions extends LocalSentryOptions {
-  // Future: add other setup-specific options here
+  language?: 'js' | 'py';  // Filter by language (e.g., "js" or "py")
 }
 
 export interface RunOptions extends LocalSentryOptions {


### PR DESCRIPTION
Adds a way of calling `npm run cli setup` for a specific language.

Also updates the action `language` to be optional. If none is passed, both js and py tests are set up and run, otherwise only the specific language.

Introduces a breaking change to the action, passing the language `python` is no longer supported and it should be either `js`, `py` or nothing at all to run both.