### PR TITLE
fix(python): Stop passing DSN to mocked transport

### DIFF
--- a/sdks/README.md
+++ b/sdks/README.md
@@ -402,7 +402,6 @@ def before_all():
 
     # Initialize Sentry
     sentry_sdk.init(
-        dsn=os.getenv("SENTRY_DSN", "https://public@127.0.0.1/1"),
         traces_sample_rate=1.0,
         transport=mock_transport_instance,
         integrations=[

--- a/sdks/py/_test-utils/README.md
+++ b/sdks/py/_test-utils/README.md
@@ -151,7 +151,6 @@ def before_all():
 
     # Initialize Sentry
     sentry_sdk.init(
-        dsn=os.getenv("SENTRY_DSN", "https://public@127.0.0.1/1"),
         traces_sample_rate=1.0,
         transport=mock_transport_instance,
         integrations=[

--- a/sdks/py/_test-utils/mock_transport.py
+++ b/sdks/py/_test-utils/mock_transport.py
@@ -135,7 +135,7 @@ class MockTransportCapture:
 _mock_transport_capture: Optional[MockTransportCapture] = None
 
 
-def create_mock_transport(options: Dict[str, Any]) -> Any:
+def create_mock_transport(options: Optional[Dict[str, Any]] = None) -> Any:
     """
     Create a mock transport factory (to be passed to sentry_sdk.init)
 

--- a/sdks/py/anthropic/setup.py
+++ b/sdks/py/anthropic/setup.py
@@ -24,13 +24,10 @@ load_dotenv(dotenv_path=env_path)
 # Pre-initialize mock transport (required for Python)
 mt._mock_transport_capture = MockTransportCapture()
 
-mock_transport_instance = create_mock_transport(
-    options={"dsn": os.getenv("SENTRY_DSN", "https://public@127.0.0.1/1")}
-)
+mock_transport_instance = create_mock_transport()
 
 # Initialize Sentry with Anthropic integration (auto-enabled)
 sentry_sdk.init(
-    dsn=os.getenv("SENTRY_DSN", "https://public@127.0.0.1/1"),
     traces_sample_rate=1.0,
     transport=mock_transport_instance,
     send_default_pii=True,

--- a/sdks/py/google-genai/setup.py
+++ b/sdks/py/google-genai/setup.py
@@ -25,13 +25,10 @@ load_dotenv(dotenv_path=env_path)
 # Pre-initialize mock transport (required for Python)
 mt._mock_transport_capture = MockTransportCapture()
 
-mock_transport_instance = create_mock_transport(
-    options={"dsn": os.getenv("SENTRY_DSN", "https://public@127.0.0.1/1")}
-)
+mock_transport_instance = create_mock_transport()
 
 # Initialize Sentry with Google GenAI integration
 sentry_sdk.init(
-    dsn=os.getenv("SENTRY_DSN", "https://public@127.0.0.1/1"),
     traces_sample_rate=1.0,
     transport=mock_transport_instance,
     send_default_pii=True,

--- a/sdks/py/langchain/setup.py
+++ b/sdks/py/langchain/setup.py
@@ -24,13 +24,10 @@ load_dotenv(dotenv_path=env_path)
 # Pre-initialize mock transport (required for Python)
 mt._mock_transport_capture = MockTransportCapture()
 
-mock_transport_instance = create_mock_transport(
-    options={"dsn": os.getenv("SENTRY_DSN", "https://public@127.0.0.1/1")}
-)
+mock_transport_instance = create_mock_transport()
 
 # Initialize Sentry with LangChain integration (auto-enabled)
 sentry_sdk.init(
-    dsn=os.getenv("SENTRY_DSN", "https://public@127.0.0.1/1"),
     traces_sample_rate=1.0,
     transport=mock_transport_instance,
     send_default_pii=True,

--- a/sdks/py/langgraph/setup.py
+++ b/sdks/py/langgraph/setup.py
@@ -25,14 +25,11 @@ load_dotenv(dotenv_path=env_path)
 # Pre-initialize mock transport (required for Python)
 mt._mock_transport_capture = MockTransportCapture()
 
-mock_transport_instance = create_mock_transport(
-    options={"dsn": os.getenv("SENTRY_DSN", "https://public@127.0.0.1/1")}
-)
+mock_transport_instance = create_mock_transport()
 
 # Initialize Sentry with LangGraph integration (auto-enabled)
 # Disable OpenAI integration to avoid double counting
 sentry_sdk.init(
-    dsn=os.getenv("SENTRY_DSN", "https://public@127.0.0.1/1"),
     traces_sample_rate=1.0,
     transport=mock_transport_instance,
     send_default_pii=True,

--- a/sdks/py/litellm/setup.py
+++ b/sdks/py/litellm/setup.py
@@ -25,13 +25,10 @@ load_dotenv(dotenv_path=env_path)
 # Pre-initialize mock transport (required for Python)
 mt._mock_transport_capture = MockTransportCapture()
 
-mock_transport_instance = create_mock_transport(
-    options={"dsn": os.getenv("SENTRY_DSN", "https://public@127.0.0.1/1")}
-)
+mock_transport_instance = create_mock_transport()
 
 # Initialize Sentry with LiteLLM integration
 sentry_sdk.init(
-    dsn=os.getenv("SENTRY_DSN", "https://public@127.0.0.1/1"),
     traces_sample_rate=1.0,
     transport=mock_transport_instance,
     send_default_pii=True,

--- a/sdks/py/openai-agents/setup.py
+++ b/sdks/py/openai-agents/setup.py
@@ -26,13 +26,10 @@ load_dotenv(dotenv_path=env_path)
 # Pre-initialize mock transport (required for Python)
 mt._mock_transport_capture = MockTransportCapture()
 
-mock_transport_instance = create_mock_transport(
-    options={"dsn": os.getenv("SENTRY_DSN", "https://public@127.0.0.1/1")}
-)
+mock_transport_instance = create_mock_transport()
 
 # Initialize Sentry with OpenAI Agents integration
 sentry_sdk.init(
-    dsn=os.getenv("SENTRY_DSN", "https://public@127.0.0.1/1"),
     traces_sample_rate=1.0,
     transport=mock_transport_instance,
     send_default_pii=True,

--- a/sdks/py/openai/setup.py
+++ b/sdks/py/openai/setup.py
@@ -24,13 +24,10 @@ load_dotenv(dotenv_path=env_path)
 # Pre-initialize mock transport (required for Python)
 mt._mock_transport_capture = MockTransportCapture()
 
-mock_transport_instance = create_mock_transport(
-    options={"dsn": os.getenv("SENTRY_DSN", "https://public@127.0.0.1/1")}
-)
+mock_transport_instance = create_mock_transport()
 
 # Initialize Sentry with OpenAI integration (auto-enabled)
 sentry_sdk.init(
-    dsn=os.getenv("SENTRY_DSN", "https://public@127.0.0.1/1"),
     traces_sample_rate=1.0,
     transport=mock_transport_instance,
     send_default_pii=True,

--- a/sdks/py/pydantic-ai/setup.py
+++ b/sdks/py/pydantic-ai/setup.py
@@ -26,14 +26,11 @@ load_dotenv(dotenv_path=env_path)
 # Pre-initialize mock transport (required for Python)
 mt._mock_transport_capture = MockTransportCapture()
 
-mock_transport_instance = create_mock_transport(
-    options={"dsn": os.getenv("SENTRY_DSN", "https://public@127.0.0.1/1")}
-)
+mock_transport_instance = create_mock_transport()
 
 # Initialize Sentry with Pydantic AI integration
 # Disable OpenAI integration to avoid double counting
 sentry_sdk.init(
-    dsn=os.getenv("SENTRY_DSN", "https://public@127.0.0.1/1"),
     traces_sample_rate=1.0,
     transport=mock_transport_instance,
     send_default_pii=True,


### PR DESCRIPTION
Avoid a `BadDsn` exception due to unnecessary parsing.