### PR TITLE
feat: add severity classes for test check failures

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1031,8 +1031,11 @@ export class Orchestrator {
               `  ${colors.yellow}⊘${colors.reset} ${colors.dim}${check.name}${colors.reset} ${colors.gray}(${reason})${colors.reset}`,
             );
           } else {
+            const sev = (check as any).severity || "normal";
+            const sevIcon = sev === "critical" ? "❗" : sev === "warning" ? "⚠ " : "✗ ";
+            const sevColor = sev === "critical" ? colors.red : sev === "warning" ? colors.yellow : colors.red;
             console.log(
-              `  ${colors.red}✗${colors.reset} ${colors.bright}${check.name}${colors.reset}`,
+              `  ${sevColor}${sevIcon}${colors.reset} ${colors.bright}${check.name}${colors.reset}`,
             );
             if (check.error) {
               // Print error message with indentation

--- a/src/reporters/html-generator.ts
+++ b/src/reporters/html-generator.ts
@@ -296,6 +296,7 @@ function TestMatrix({ report }: { report: Report }) {
 interface ReportCheckResult {
   name: string;
   status: "passed" | "failed" | "skipped";
+  severity?: "critical" | "normal" | "warning";
   error?: string;
   skipReason?: string;
   errorLocations?: Array<{
@@ -342,6 +343,64 @@ function renderSpanJson(span: unknown, highlightAttrs?: Set<string>): string {
  * each group has a toggle icon to show/hide that span's JSON with failing
  * attributes highlighted.
  */
+/**
+ * Render a single failed check result with its error locations grouped by span.
+ */
+function FailedCheckDetail({
+  cr,
+  spanById,
+}: {
+  cr: ReportCheckResult;
+  spanById: Map<string, unknown>;
+}) {
+  const severity = cr.severity || "normal";
+  const icon = severity === "critical" ? "❗" : severity === "warning" ? "⚠" : "✗";
+
+  const groups = new Map<string, typeof cr.errorLocations>();
+  if (cr.errorLocations) {
+    for (const loc of cr.errorLocations) {
+      if (!groups.has(loc.spanId)) groups.set(loc.spanId, []);
+      groups.get(loc.spanId)!.push(loc);
+    }
+  }
+
+  return html`<div class="check-result check-failed check-severity-${severity}">
+    <span class="check-icon">${icon}</span>
+    <span class="check-name">${cr.name}</span>
+    ${cr.error ? html`<div class="check-error-msg">${cr.error}</div>` : ""}
+    ${groups.size > 0
+      ? html`<div class="check-locations">
+          ${[...groups.entries()].map(([spanId, locs]) => {
+            const highlightAttrs = new Set<string>();
+            for (const loc of locs!) {
+              if (loc.attribute) highlightAttrs.add(loc.attribute);
+            }
+            const span = spanById.get(spanId);
+            return html`<div class="span-group">
+              <div class="span-group-header">
+                <span class="loc-span">${spanId.substring(0, 8)}</span>
+                ${span
+                  ? html`<button class="show-span-btn" onclick="toggleSpanPreview(this)" title="Show/hide span JSON" dangerouslySetInnerHTML=${{ __html: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>' }}></button>`
+                  : ""}
+              </div>
+              <div class="span-group-errors">
+                ${locs!.map(
+                  (loc) => html`<div class="check-location">
+                    ${loc.attribute ? html`<span class="loc-attr">${loc.attribute}</span>` : ""}
+                    <span class="loc-msg">${loc.message}</span>
+                  </div>`,
+                )}
+              </div>
+              ${span
+                ? html`<pre class="span-preview" style="display:none" dangerouslySetInnerHTML=${{ __html: renderSpanJson(span, highlightAttrs) }}></pre>`
+                : ""}
+            </div>`;
+          })}
+        </div>`
+      : ""}
+  </div>`;
+}
+
 function CheckResultsBreakdown({
   checkResults,
   spans,
@@ -360,69 +419,43 @@ function CheckResultsBreakdown({
     }
   }
 
-  const items = checkResults.map((cr) => {
-    if (cr.status === "passed") {
-      return html`<div class="check-result check-passed">
-        <span class="check-icon">✓</span>
-        <span class="check-name">${cr.name}</span>
-      </div>`;
-    } else if (cr.status === "skipped") {
-      return html`<div class="check-result check-skipped">
-        <span class="check-icon">○</span>
-        <span class="check-name">${cr.name}</span>
-        ${cr.skipReason ? html`<span class="check-skip-reason">(${cr.skipReason})</span>` : ""}
-      </div>`;
-    } else {
-      // failed - group error locations by spanId
-      const groups = new Map<string, typeof cr.errorLocations>();
-      if (cr.errorLocations) {
-        for (const loc of cr.errorLocations) {
-          if (!groups.has(loc.spanId)) groups.set(loc.spanId, []);
-          groups.get(loc.spanId)!.push(loc);
-        }
-      }
+  // Split checks by severity, keeping original order within each group
+  const severityOrder: Array<"critical" | "normal" | "warning"> = ["critical", "normal", "warning"];
+  const groups: Record<string, ReportCheckResult[]> = { critical: [], normal: [], warning: [] };
+  for (const cr of checkResults) {
+    const sev = cr.severity || "normal";
+    groups[sev].push(cr);
+  }
 
-      return html`<div class="check-result check-failed">
-        <span class="check-icon">✗</span>
-        <span class="check-name">${cr.name}</span>
-        ${cr.error ? html`<div class="check-error-msg">${cr.error}</div>` : ""}
-        ${groups.size > 0
-          ? html`<div class="check-locations">
-              ${[...groups.entries()].map(([spanId, locs]) => {
-                const highlightAttrs = new Set<string>();
-                for (const loc of locs!) {
-                  if (loc.attribute) highlightAttrs.add(loc.attribute);
-                }
-                const span = spanById.get(spanId);
-                return html`<div class="span-group">
-                  <div class="span-group-header">
-                    <span class="loc-span">${spanId.substring(0, 8)}</span>
-                    ${span
-                      ? html`<button class="show-span-btn" onclick="toggleSpanPreview(this)" title="Show/hide span JSON" dangerouslySetInnerHTML=${{ __html: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>' }}></button>`
-                      : ""}
-                  </div>
-                  <div class="span-group-errors">
-                    ${locs!.map(
-                      (loc) => html`<div class="check-location">
-                        ${loc.attribute ? html`<span class="loc-attr">${loc.attribute}</span>` : ""}
-                        <span class="loc-msg">${loc.message}</span>
-                      </div>`,
-                    )}
-                  </div>
-                  ${span
-                    ? html`<pre class="span-preview" style="display:none" dangerouslySetInnerHTML=${{ __html: renderSpanJson(span, highlightAttrs) }}></pre>`
-                    : ""}
-                </div>`;
-              })}
-            </div>`
-          : ""}
+  const sections = severityOrder
+    .filter((sev) => groups[sev].length > 0)
+    .map((sev) => {
+      const label = sev === "critical" ? "Critical" : sev === "warning" ? "Warnings" : "Checks";
+      const items = groups[sev].map((cr) => {
+        if (cr.status === "passed") {
+          return html`<div class="check-result check-passed">
+            <span class="check-icon">✓</span>
+            <span class="check-name">${cr.name}</span>
+          </div>`;
+        } else if (cr.status === "skipped") {
+          return html`<div class="check-result check-skipped">
+            <span class="check-icon">○</span>
+            <span class="check-name">${cr.name}</span>
+            ${cr.skipReason ? html`<span class="check-skip-reason">(${cr.skipReason})</span>` : ""}
+          </div>`;
+        } else {
+          return FailedCheckDetail({ cr, spanById });
+        }
+      });
+
+      return html`<div class="check-section check-section-${sev}">
+        <div class="check-section-label">${label}</div>
+        ${items}
       </div>`;
-    }
-  });
+    });
 
   return html`<div class="check-results-breakdown">
-    <strong>Check Results:</strong>
-    ${items}
+    ${sections}
   </div>`;
 }
 
@@ -445,6 +478,17 @@ function FailedTestsDetails({ tests }: { tests: Test[] }) {
       const spanCount = extra?.spanCount as number | undefined;
       const checkResults = extra?.checkResults as ReportCheckResult[] | undefined;
 
+      // Count failures by severity for summary badges
+      const severityCounts = { critical: 0, normal: 0, warning: 0 };
+      if (checkResults) {
+        for (const cr of checkResults) {
+          if (cr.status === "failed") {
+            const sev = cr.severity || "normal";
+            severityCounts[sev]++;
+          }
+        }
+      }
+
       return html`
         <details class="failed-test">
           <summary>
@@ -455,6 +499,17 @@ function FailedTestsDetails({ tests }: { tests: Test[] }) {
                 : "unknown"}</strong
             >
             :: ${caseId}
+            <span class="severity-badges">
+              ${severityCounts.critical > 0
+                ? html`<span class="sev-badge sev-badge-critical">${"❗"} ${severityCounts.critical}</span>`
+                : ""}
+              ${severityCounts.normal > 0
+                ? html`<span class="sev-badge sev-badge-normal">${"✗"} ${severityCounts.normal}</span>`
+                : ""}
+              ${severityCounts.warning > 0
+                ? html`<span class="sev-badge sev-badge-warning">${"⚠"} ${severityCounts.warning}</span>`
+                : ""}
+            </span>
             <span class="duration">(${test.duration}ms)</span>
           </summary>
           <div class="error-details">
@@ -719,6 +774,34 @@ export function generateHTML(report: Report): string {
             color: #c62828;
             margin-right: 8px;
           }
+          .severity-badges {
+            display: inline-flex;
+            gap: 6px;
+            margin-left: 8px;
+            vertical-align: middle;
+          }
+          .sev-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 3px;
+            font-size: 11px;
+            font-weight: 600;
+            padding: 1px 7px;
+            border-radius: 10px;
+            line-height: 1.4;
+          }
+          .sev-badge-critical {
+            background: #ffcdd2;
+            color: #b71c1c;
+          }
+          .sev-badge-normal {
+            background: #ffcdd2;
+            color: #c62828;
+          }
+          .sev-badge-warning {
+            background: #fff3e0;
+            color: #e65100;
+          }
           .duration {
             color: #666;
             font-size: 12px;
@@ -742,16 +825,35 @@ export function generateHTML(report: Report): string {
           /* Check results breakdown */
           .check-results-breakdown {
             margin: 10px 0 15px 0;
-            padding: 12px;
-            background: #fafafa;
+          }
+          .check-section {
+            margin-bottom: 8px;
+            padding: 8px 12px;
             border: 1px solid #e0e0e0;
             border-radius: 4px;
+            background: #fafafa;
           }
-          .check-results-breakdown > strong {
-            display: block;
-            margin-bottom: 8px;
-            font-size: 14px;
-            color: #333;
+          .check-section-label {
+            font-size: 11px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: 4px;
+            color: #888;
+          }
+          .check-section-critical {
+            border-color: #ef9a9a;
+            background: #fff5f5;
+          }
+          .check-section-critical .check-section-label {
+            color: #b71c1c;
+          }
+          .check-section-warning {
+            border-color: #ffe082;
+            background: #fffde7;
+          }
+          .check-section-warning .check-section-label {
+            color: #f57f17;
           }
           .check-result {
             padding: 4px 0 4px 8px;
@@ -794,6 +896,20 @@ export function generateHTML(report: Report): string {
           }
           .check-failed .check-name {
             font-weight: 600;
+          }
+          .check-severity-critical {
+            border-left-color: #b71c1c;
+            background: #ffebee;
+          }
+          .check-severity-critical .check-icon {
+            color: #b71c1c;
+          }
+          .check-severity-warning {
+            border-left-color: #f9a825;
+            background: #fffde7;
+          }
+          .check-severity-warning .check-icon {
+            color: #f57f17;
           }
           .check-error-msg {
             margin: 4px 0 4px 24px;

--- a/src/reporters/live-status.ts
+++ b/src/reporters/live-status.ts
@@ -169,7 +169,10 @@ export class LiveStatusReporter {
 
           // Show check results
           for (const check of test.checkResults) {
-            const checkIcon = this.getStatusIcon(check.status);
+            const sev = (check as any).severity || 'normal';
+            const checkIcon = check.status === 'failed'
+              ? (sev === 'critical' ? `${colors.red}❗${colors.reset}` : sev === 'warning' ? `${colors.yellow}⚠${colors.reset}` : this.getStatusIcon(check.status))
+              : this.getStatusIcon(check.status);
             const checkLine = `      ${checkIcon} ${colors.dim}${check.name}${colors.reset}`;
             
             if (check.status === 'skipped' && check.skipReason) {

--- a/src/test-cases/README.md
+++ b/src/test-cases/README.md
@@ -35,11 +35,10 @@ export const basicLLMTest: TestDefinition = {
     tools: [/* ... */],
   },
   
-  // Validation function (runs in orchestrator with Chai)
-  checks(spans) {
-    expect(spans.length).to.be.greaterThan(0);
-    // ... more assertions
-  }
+  // Checks grouped by severity (critical, normal, warning)
+  criticalChecks: [/* must pass */],
+  checks: [/* normal checks */],
+  warningChecks: [/* optional checks */],
 };
 ```
 
@@ -82,7 +81,7 @@ Tests for frameworks that support agentic workflows (subset of frameworks):
 2. **Define test:**
    ```typescript
    import { TestDefinition } from '../../types.js';
-   import { expect } from 'chai';
+   import { checkAISpanCount, checkChatSpanAttributes } from '../checks.js';
    
    export const myTest: TestDefinition = {
      name: 'My Test',
@@ -96,10 +95,16 @@ Tests for frameworks that support agentic workflows (subset of frameworks):
        prompt: '...',
      },
      
-     checks(spans) {
-       // Chai assertions
-       expect(spans.length).to.be.greaterThan(0);
-     }
+     // Checks grouped by severity
+     criticalChecks: [
+       checkAISpanCount(1),       // Must pass or test is broken
+     ],
+     checks: [
+       checkChatSpanAttributes,   // Normal correctness checks
+     ],
+     warningChecks: [
+       // Optional/OTel migration checks (failures don't fail the test)
+     ],
    };
    
    export default myTest;
@@ -121,52 +126,63 @@ Tests for frameworks that support agentic workflows (subset of frameworks):
 
 ## Validation Guidelines
 
-The `checks(spans)` function receives captured Sentry spans and should validate:
+Checks are reusable functions defined in `checks.ts` and `otel-checks.ts`. They throw `CheckError` (with `ErrorLocation[]`) on failure.
 
-### Basic Checks (all tests)
+### Check Severity
+
+Tests define checks in three tiers:
+
+- **`criticalChecks`** — Structural checks (span existence, hierarchy). If these fail, the test is fundamentally broken.
+- **`checks`** — Normal data correctness checks (token usage, message schema, tool calls).
+- **`warningChecks`** — Optional/OTel migration checks. Failures are reported but don't fail the test.
+
+### Writing Custom Checks
 
 ```typescript
-checks(spans) {
-  const genAISpans = spans.filter(s => s.op?.startsWith('gen_ai'));
-  
-  // Should capture spans
-  expect(genAISpans.length).to.be.at.least(1);
-  
-  // Basic span structure
-  expect(genAISpans[0].op).to.exist;
-  expect(genAISpans[0].start_timestamp).to.exist;
-  expect(genAISpans[0].timestamp).to.exist;
-}
+import { Check, ErrorLocation } from '../../types.js';
+import { CheckError } from '../../validator.js';
+import { extractGenAISpans } from '../utils.js';
+
+const myCheck: Check = {
+  name: 'myCheck',
+  fn: (spans, config, testDef) => {
+    const aiSpans = extractGenAISpans(spans);
+    if (aiSpans.length === 0) {
+      throw new CheckError('Expected at least one AI span');
+    }
+
+    const errors: ErrorLocation[] = [];
+    for (const span of aiSpans) {
+      if (!span.data?.['gen_ai.request.model']) {
+        errors.push({
+          spanId: span.span_id,
+          attribute: 'gen_ai.request.model',
+          message: 'Model attribute is missing',
+        });
+      }
+    }
+    if (errors.length > 0) {
+      throw new CheckError('Model attribute validation failed', errors);
+    }
+  },
+};
 ```
 
-### AI Monitoring Attributes
+### Reusable Check Functions
+
+Use the built-in checks from `checks.ts` for common validations:
 
 ```typescript
-// Model information
-expect(span.data['gen_ai.request.model']).to.exist;
+import {
+  checkAISpanCount,
+  checkChatSpanAttributes,
+  checkValidTokenUsage,
+  checkInputMessagesSchema,
+} from '../checks.js';
 
-// Token usage (if available)
-if (span.data['gen_ai.usage.input_tokens']) {
-  expect(span.data['gen_ai.usage.input_tokens']).to.be.a('number');
-}
-
-// Prompt data (if captured)
-if (span.data['gen_ai.prompt']) {
-  expect(span.data['gen_ai.prompt']).to.be.a('string');
-}
-```
-
-### Agent-Specific Checks
-
-```typescript
-// Agent span exists
-const agentSpan = spans.find(s => s.op === 'gen_ai.invoke_agent');
-expect(agentSpan).to.exist;
-
-// Tool calls captured
-if (span.data['gen_ai.tool_calls']) {
-  expect(span.data['gen_ai.tool_calls']).to.be.an('array');
-}
+// In your test definition:
+criticalChecks: [checkAISpanCount(1), checkChatSpanAttributes],
+checks: [checkValidTokenUsage, checkInputMessagesSchema],
 ```
 
 ## Framework Compatibility

--- a/src/test-cases/agents/basic.ts
+++ b/src/test-cases/agents/basic.ts
@@ -43,15 +43,20 @@ export const basicAgentTest: TestDefinition = {
     },
   ],
 
-  checks: [
+  criticalChecks: [
     checkAgentSpanAttributes,
     checkChatSpanAttributes,
-    checkValidTokenUsage,
     checkAgentHierarchy,
+  ],
+
+  checks: [
+    checkValidTokenUsage,
     checkInputMessagesSchema,
+  ],
+
+  warningChecks: [
     checkInputTokensCached,
     checkOutputTokensReasoning,
-    // OTel-aligned checks (soft failure if not migrated)
     checkInputMessages,
     checkOutputMessages,
     checkSystemInstructions,

--- a/src/test-cases/agents/long-input.ts
+++ b/src/test-cases/agents/long-input.ts
@@ -73,14 +73,19 @@ export const longInputAgentTest: TestDefinition = {
     },
   ],
 
-  checks: [
+  criticalChecks: [
     checkAgentSpanAttributes,
     checkChatSpanAttributes,
+    checkAgentHierarchy,
+  ],
+
+  checks: [
     checkMessageTrimming,
     checkTrimmingMetadata,
-    checkAgentHierarchy,
     checkInputMessagesSchema,
-    // OTel-aligned checks (soft failure if not migrated)
+  ],
+
+  warningChecks: [
     checkInputMessages,
     checkOutputMessages,
   ],

--- a/src/test-cases/agents/tool-call.ts
+++ b/src/test-cases/agents/tool-call.ts
@@ -96,12 +96,15 @@ export const toolCallAgentTest: TestDefinition = {
     },
   ],
 
-  checks: [
+  criticalChecks: [
     checkAgentSpanAttributes,
     checkChatSpanAttributes,
     checkToolSpanAttributes,
-    checkValidTokenUsage,
     checkAgentHierarchy,
+  ],
+
+  checks: [
+    checkValidTokenUsage,
     checkAvailableTools,
     checkResponseToolCalls([
       { name: "add", arguments: { a: 3, b: 5 } },
@@ -124,9 +127,11 @@ export const toolCallAgentTest: TestDefinition = {
       },
     ]),
     checkInputMessagesSchema,
+  ],
+
+  warningChecks: [
     checkInputTokensCached,
     checkOutputTokensReasoning,
-    // OTel-aligned checks (soft failure if not migrated)
     checkInputMessages,
     checkOutputMessages,
     checkToolDefinitions,

--- a/src/test-cases/agents/tool-error.ts
+++ b/src/test-cases/agents/tool-error.ts
@@ -5,8 +5,7 @@
  * Validates that Sentry captures the error correctly in spans.
  */
 
-import { expect } from "chai";
-import { TestDefinition, CapturedSpan, Check } from "../../types.js";
+import { TestDefinition, CapturedSpan, Check, ErrorLocation } from "../../types.js";
 import {
   checkChatSpanAttributes,
   checkAgentSpanAttributes,
@@ -24,6 +23,7 @@ import {
   checkOutputMessagesToolCalls,
 } from "../otel-checks.js";
 import { extractGenAISpans, findToolSpans } from "../utils.js";
+import { CheckError } from "../../validator.js";
 
 /**
  * Check that a tool error was captured in spans
@@ -32,35 +32,51 @@ const checkToolErrorSpan: Check = {
   name: "checkToolErrorSpan",
   fn: (spans: CapturedSpan[], config, testDef) => {
     const toolSpans = findToolSpans(extractGenAISpans(spans));
-    expect(
-      toolSpans.length,
-      "Should have at least one tool span",
-    ).to.be.greaterThan(0);
+    if (toolSpans.length === 0) {
+      throw new CheckError("Should have at least one tool span but found none");
+    }
 
     // Get expected tool name from test definition
     const expectedToolName = testDef.agent?.tools?.[0]?.name;
-    expect(expectedToolName, "Test should define at least one tool").to.exist;
+    if (!expectedToolName) {
+      throw new CheckError("Test should define at least one tool with a name");
+    }
 
     // Find the span for the expected tool
     const toolSpan = toolSpans.find(
       (s) =>
         s.data?.["gen_ai.tool.name"] === expectedToolName ||
-        s.description?.includes(expectedToolName!),
+        s.description?.includes(expectedToolName),
     );
-    expect(toolSpan, `Should have a span for tool "${expectedToolName}"`).to
-      .exist;
+    if (!toolSpan) {
+      throw new CheckError(
+        `Should have a span for tool "${expectedToolName}"`,
+        toolSpans.map((s) => ({
+          spanId: s.span_id,
+          attribute: "gen_ai.tool.name",
+          message: `Tool span has name="${s.data?.["gen_ai.tool.name"]}" / description="${s.description}", expected "${expectedToolName}"`,
+        })),
+      );
+    }
 
     // Check for error indicators
-    const span = toolSpan!;
     const hasError =
-      span.status === "error" ||
-      span.status === "internal_error" ||
-      span.data?.["error"] !== undefined ||
-      span.data?.["exception"] !== undefined ||
-      span.data?.["gen_ai.tool.error"] !== undefined ||
-      (span.tags && span.tags["error"] === true);
+      toolSpan.status === "error" ||
+      toolSpan.status === "internal_error" ||
+      toolSpan.data?.["error"] !== undefined ||
+      toolSpan.data?.["exception"] !== undefined ||
+      toolSpan.data?.["gen_ai.tool.error"] !== undefined ||
+      (toolSpan.tags && toolSpan.tags["error"] === true);
 
-    expect(hasError, "Tool span should have an error indicator").to.be.true;
+    if (!hasError) {
+      throw new CheckError(
+        "Tool span should have an error indicator (status=error, data.error, data.exception, gen_ai.tool.error, or tags.error)",
+        [{
+          spanId: toolSpan.span_id,
+          message: `Tool span has status="${toolSpan.status}" with no error indicators`,
+        }],
+      );
+    }
   },
 };
 
@@ -106,18 +122,23 @@ export const toolErrorAgentTest: TestDefinition = {
     },
   ],
 
-  checks: [
+  criticalChecks: [
     checkAgentSpanAttributes,
     checkChatSpanAttributes,
     checkToolSpanAttributes,
     checkAgentHierarchy,
+  ],
+
+  checks: [
     checkAvailableTools,
     checkResponseToolCalls([
       { name: "read_file", arguments: { path: "/nonexistent/file.txt" } },
     ]),
     checkInputMessagesSchema,
     checkToolErrorSpan,
-    // OTel-aligned checks (soft failure if not migrated)
+  ],
+
+  warningChecks: [
     checkInputMessages,
     checkOutputMessages,
     checkToolDefinitions,

--- a/src/test-cases/agents/vision.ts
+++ b/src/test-cases/agents/vision.ts
@@ -64,14 +64,19 @@ export const visionAgentTest: TestDefinition = {
     },
   ],
 
-  checks: [
+  criticalChecks: [
     checkAgentSpanAttributes,
     checkChatSpanAttributes,
-    checkValidTokenUsage,
     checkAgentHierarchy,
+  ],
+
+  checks: [
+    checkValidTokenUsage,
     checkInputMessagesSchema,
     checkBinaryRedaction,
-    // OTel-aligned checks (soft failure if not migrated)
+  ],
+
+  warningChecks: [
     checkInputMessages,
     checkOutputMessages,
     checkSystemInstructions,

--- a/src/test-cases/llm/basic-error.ts
+++ b/src/test-cases/llm/basic-error.ts
@@ -5,10 +5,10 @@
  * Uses respx to mock a 500 Internal Server Error response.
  */
 
-import { expect } from "chai";
 import { TestDefinition, Check } from "../../types.js";
 import { checkAISpanCount } from "../checks.js";
 import { extractGenAISpans } from "../utils.js";
+import { CheckError } from "../../validator.js";
 
 /**
  * Check that the span has error information
@@ -17,10 +17,9 @@ const checkErrorCaptured: Check = {
   name: "checkErrorCaptured",
   fn: (spans) => {
     const aiSpans = extractGenAISpans(spans);
-    expect(
-      aiSpans.length,
-      "Should have at least one AI span",
-    ).to.be.greaterThan(0);
+    if (aiSpans.length === 0) {
+      throw new CheckError("Should have at least one AI span but found none");
+    }
 
     // Find a span with error status or error data
     const errorSpan = aiSpans.find(
@@ -31,8 +30,15 @@ const checkErrorCaptured: Check = {
         span.data?.["http.status_code"] === 500,
     );
 
-    expect(errorSpan, "Expected to find a span with error information").to
-      .exist;
+    if (!errorSpan) {
+      throw new CheckError(
+        "Expected to find a span with error information (internal_error, unknown_error, error.type, or http.status_code=500)",
+        aiSpans.map((span) => ({
+          spanId: span.span_id,
+          message: `Span has status="${span.status}" with no error indicators`,
+        })),
+      );
+    }
   },
 };
 
@@ -54,7 +60,9 @@ export const basicErrorLLMTest: TestDefinition = {
     },
   ],
 
-  checks: [checkAISpanCount({ min: 1 }), checkErrorCaptured],
+  criticalChecks: [checkAISpanCount({ min: 1 }), checkErrorCaptured],
+
+  checks: [],
 };
 
 export default basicErrorLLMTest;

--- a/src/test-cases/llm/basic.ts
+++ b/src/test-cases/llm/basic.ts
@@ -35,14 +35,19 @@ export const basicLLMTest: TestDefinition = {
     },
   ],
 
-  checks: [
+  criticalChecks: [
     checkAISpanCount(1),
     checkChatSpanAttributes,
+  ],
+
+  checks: [
     checkValidTokenUsage,
     checkInputMessagesSchema,
+  ],
+
+  warningChecks: [
     checkInputTokensCached,
     checkOutputTokensReasoning,
-    // OTel-aligned checks (soft failure if not migrated)
     checkInputMessages,
     checkOutputMessages,
     checkSystemInstructions,

--- a/src/test-cases/llm/long-input.ts
+++ b/src/test-cases/llm/long-input.ts
@@ -53,12 +53,17 @@ export const longInputLLMTest: TestDefinition = {
     },
   ],
 
-  checks: [
+  criticalChecks: [
     checkChatSpanAttributes,
+  ],
+
+  checks: [
     checkMessageTrimming,
     checkTrimmingMetadata,
     checkInputMessagesSchema,
-    // OTel-aligned checks (soft failure if not migrated)
+  ],
+
+  warningChecks: [
     checkInputMessages,
     checkOutputMessages,
     checkSystemInstructions,

--- a/src/test-cases/llm/multi-turn.ts
+++ b/src/test-cases/llm/multi-turn.ts
@@ -5,8 +5,7 @@
  * Validates that Sentry captures multiple gen_ai spans correctly.
  */
 
-import { expect } from "chai";
-import { TestDefinition, Check } from "../../types.js";
+import { TestDefinition, Check, ErrorLocation } from "../../types.js";
 import {
   checkAISpanCount,
   checkChatSpanAttributes,
@@ -21,6 +20,7 @@ import {
   checkSystemInstructions,
 } from "../otel-checks.js";
 import { extractGenAISpans, skipIf } from "../utils.js";
+import { CheckError } from "../../validator.js";
 
 /**
  * Check that input tokens increase with each turn (more conversation history)
@@ -40,8 +40,27 @@ const checkTokenProgression: Check = {
     );
 
     // Input tokens should increase with each turn (more conversation history)
-    expect(inputTokens[1]).to.be.greaterThan(inputTokens[0]);
-    expect(inputTokens[2]).to.be.greaterThan(inputTokens[1]);
+    const errors: ErrorLocation[] = [];
+    if (!(inputTokens[1] > inputTokens[0])) {
+      errors.push({
+        spanId: aiSpans[1].span_id,
+        attribute: "gen_ai.usage.input_tokens",
+        message: `Turn 2 input tokens (${inputTokens[1]}) should be greater than turn 1 (${inputTokens[0]})`,
+      });
+    }
+    if (!(inputTokens[2] > inputTokens[1])) {
+      errors.push({
+        spanId: aiSpans[2].span_id,
+        attribute: "gen_ai.usage.input_tokens",
+        message: `Turn 3 input tokens (${inputTokens[2]}) should be greater than turn 2 (${inputTokens[1]})`,
+      });
+    }
+    if (errors.length > 0) {
+      throw new CheckError(
+        `Input token progression failed: tokens should increase with each turn`,
+        errors,
+      );
+    }
   },
 };
 
@@ -87,15 +106,20 @@ export const multiTurnLLMTest: TestDefinition = {
     },
   ],
 
-  checks: [
+  criticalChecks: [
     checkAISpanCount(3),
     checkChatSpanAttributes,
+  ],
+
+  checks: [
     checkValidTokenUsage,
     checkTokenProgression,
     checkInputMessagesSchema,
+  ],
+
+  warningChecks: [
     checkInputTokensCached,
     checkOutputTokensReasoning,
-    // OTel-aligned checks (soft failure if not migrated)
     checkInputMessages,
     checkOutputMessages,
     checkSystemInstructions,

--- a/src/test-cases/llm/vision.ts
+++ b/src/test-cases/llm/vision.ts
@@ -54,12 +54,17 @@ export const visionLLMTest: TestDefinition = {
     },
   ],
 
-  checks: [
+  criticalChecks: [
     checkChatSpanAttributes,
+  ],
+
+  checks: [
     checkValidTokenUsage,
     checkInputMessagesSchema,
     checkBinaryRedaction,
-    // OTel-aligned checks (soft failure if not migrated)
+  ],
+
+  warningChecks: [
     checkInputMessages,
     checkOutputMessages,
     checkSystemInstructions,

--- a/src/test-cases/utils.ts
+++ b/src/test-cases/utils.ts
@@ -2,7 +2,6 @@
  * Common test utilities for span validation
  */
 
-import { expect } from "chai";
 import { CapturedSpan, ErrorLocation } from "../types.js";
 import { SkipCheckError, CheckError } from "../validator.js";
 
@@ -191,7 +190,7 @@ export function checkSpanStructure(
     : undefined;
 
   if (parentOp && !parentSpan) {
-    throw new Error(`No parent span found matching pattern: ${parentOp}`);
+    throw new CheckError(`No parent span found matching pattern: ${parentOp}`);
   }
 
   // Find child spans
@@ -206,28 +205,41 @@ export function checkSpanStructure(
   }
 
   // Check child count
-  if (minChildren !== undefined) {
-    expect(childSpans.length).to.be.at.least(
-      minChildren,
-      `Should have at least ${minChildren} child span(s)`,
-    );
+  const errors: string[] = [];
+  const locations: ErrorLocation[] = [];
+
+  if (minChildren !== undefined && childSpans.length < minChildren) {
+    const msg = `Should have at least ${minChildren} child span(s) but found ${childSpans.length}`;
+    errors.push(msg);
+    if (parentSpan) {
+      locations.push({ spanId: parentSpan.span_id, message: msg });
+    }
   }
 
-  if (exactChildren !== undefined) {
-    expect(childSpans.length).to.equal(
-      exactChildren,
-      `Should have exactly ${exactChildren} child span(s)`,
-    );
+  if (exactChildren !== undefined && childSpans.length !== exactChildren) {
+    const msg = `Should have exactly ${exactChildren} child span(s) but found ${childSpans.length}`;
+    errors.push(msg);
+    if (parentSpan) {
+      locations.push({ spanId: parentSpan.span_id, message: msg });
+    }
   }
 
   // Validate child operations
   if (childOp) {
     childSpans.forEach((child, idx) => {
-      expect(child.op).to.match(
-        childOp,
-        `Child span ${idx} operation should match pattern`,
-      );
+      if (!child.op || !child.op.match(childOp)) {
+        const msg = `Child span ${idx} operation "${child.op}" should match pattern ${childOp}`;
+        errors.push(msg);
+        locations.push({ spanId: child.span_id, attribute: "op", message: msg });
+      }
     });
+  }
+
+  if (errors.length > 0) {
+    throw new CheckError(
+      `Span structure validation failed:\n  ${errors.join("\n  ")}`,
+      locations,
+    );
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,14 @@ export interface Check {
   fn: CheckFunction;
 }
 
+/**
+ * Check severity levels, ordered from most to least severe.
+ * - critical: Core instrumentation (spans exist, correct attributes, hierarchy)
+ * - normal: Data correctness (token usage, messages schema, tool calls)
+ * - warning: Forward-looking / best-effort (OTel migration, optional token fields)
+ */
+export type CheckSeverity = "critical" | "normal" | "warning";
+
 export interface TestDefinition {
   name: string;
   description: string;
@@ -31,8 +39,12 @@ export interface TestDefinition {
   inputs: TestInput[];
   /** If true, the test should intentionally cause an API error (e.g., invalid model name) */
   causeAPIError?: boolean;
-  /** Array of check functions to run */
+  /** Critical checks - core instrumentation must work (spans exist, attributes, hierarchy) */
+  criticalChecks?: Check[];
+  /** Normal checks - data correctness (token usage, messages, tool calls) */
   checks: Check[];
+  /** Warning checks - best-effort / forward-looking (OTel migration, optional fields) */
+  warningChecks?: Check[];
 }
 
 export interface AgentDefinition {
@@ -138,6 +150,8 @@ export interface ErrorLocation {
 export interface CheckResult {
   name: string;
   status: "passed" | "failed" | "skipped";
+  /** Severity level of this check */
+  severity: CheckSeverity;
   error?: string;
   skipReason?: string;
   /** Locations within span data that caused the failure */

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -8,6 +8,7 @@ import {
   FrameworkConfig,
   CheckResult,
   Check,
+  CheckSeverity,
   ErrorLocation,
 } from "./types.js";
 
@@ -72,10 +73,21 @@ export class Validator {
     const checkResults: CheckResult[] = [];
     const errors: Error[] = [];
 
-    // Get checks array from test definition
-    const checks: Check[] = testDefinition.checks || [];
+    // Build ordered list of checks with their severity
+    const checkGroups: Array<{ severity: CheckSeverity; checks: Check[] }> = [
+      { severity: "critical", checks: testDefinition.criticalChecks || [] },
+      { severity: "normal", checks: testDefinition.checks || [] },
+      { severity: "warning", checks: testDefinition.warningChecks || [] },
+    ];
 
-    if (checks.length === 0) {
+    const allChecks: Array<{ check: Check; severity: CheckSeverity }> = [];
+    for (const group of checkGroups) {
+      for (const check of group.checks) {
+        allChecks.push({ check, severity: group.severity });
+      }
+    }
+
+    if (allChecks.length === 0) {
       if (this.verbose) {
         console.log("  No checks defined for this test");
       }
@@ -86,8 +98,8 @@ export class Validator {
     const testName = testDefinition.name;
     const skippedChecks = frameworkConfig.skip?.checks?.[testName] || [];
 
-    // Run all checks
-    for (const check of checks) {
+    // Run all checks in order (critical -> normal -> warning)
+    for (const { check, severity } of allChecks) {
       const checkName = check.name;
 
       // Notify that check is starting
@@ -97,6 +109,7 @@ export class Validator {
       if (skippedChecks.includes(checkName)) {
         const result: CheckResult = {
           name: checkName,
+          severity,
           status: "skipped",
           skipReason: "Not supported by this framework",
         };
@@ -110,7 +123,7 @@ export class Validator {
 
       try {
         await check.fn(spans, frameworkConfig, testDefinition);
-        const result: CheckResult = { name: checkName, status: "passed" };
+        const result: CheckResult = { name: checkName, severity, status: "passed" };
         checkResults.push(result);
         onCheckResult?.(result);
         if (this.verbose) {
@@ -121,6 +134,7 @@ export class Validator {
         if (error instanceof SkipCheckError) {
           const result: CheckResult = {
             name: checkName,
+            severity,
             status: "skipped",
             skipReason: error.reason,
           };
@@ -138,6 +152,7 @@ export class Validator {
           error instanceof CheckError ? error.locations : [];
         const result: CheckResult = {
           name: checkName,
+          severity,
           status: "failed",
           error: errorMsg,
           ...(errorLocations.length > 0 && { errorLocations }),
@@ -145,7 +160,8 @@ export class Validator {
         checkResults.push(result);
         onCheckResult?.(result);
         if (this.verbose) {
-          console.error(`  ✗ ${checkName} failed: ${errorMsg}`);
+          const severityLabel = severity === "critical" ? "❗" : severity === "warning" ? "⚠" : "✗";
+          console.error(`  ${severityLabel} ${checkName} failed: ${errorMsg}`);
           if (errorLocations.length > 0) {
             for (const loc of errorLocations) {
               const spanRef = `span ${loc.spanId.substring(0, 8)}`;
@@ -158,11 +174,14 @@ export class Validator {
       }
     }
 
-    // If any check failed, throw combined error with check results
-    if (errors.length > 0) {
+    // If any non-warning check failed, throw combined error with check results
+    const nonWarningErrors = checkResults.filter(
+      (r) => r.status === "failed" && r.severity !== "warning",
+    );
+    if (nonWarningErrors.length > 0) {
       const errorMessages = errors.map((e) => e.message).join("\n");
       throw new ValidationError(
-        `${errors.length} check(s) failed:\n${errorMessages}`,
+        `${nonWarningErrors.length} check(s) failed:\n${errorMessages}`,
         checkResults,
       );
     }


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/TET-1939/split-failures-into-critical-failures-and-warnings

<img width="1347" height="892" alt="Screenshot 2026-02-11 at 10 23 53" src="https://github.com/user-attachments/assets/ff71874d-4091-43c9-8f3b-33297b496bd0" />
<img width="1324" height="720" alt="Screenshot 2026-02-11 at 10 24 41" src="https://github.com/user-attachments/assets/c5ae97cd-c198-48dd-9864-7efb18424348" />
