### PR TITLE
fix: using GOOGLE_GENAI_API_KEY instead of GOOGLE_VERTEX_*

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -98,7 +98,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GOOGLE_GENAI_API_KEY: ${{ secrets.GOOGLE_GENAI_API_KEY }}
         run: npm run test -- -j=12
 
       - name: Generate HTML report

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -93,7 +93,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GOOGLE_GENAI_API_KEY: ${{ secrets.GOOGLE_GENAI_API_KEY }}
         run: npm run test -- -j=12
 
       - name: Upload CTRF report
@@ -184,7 +184,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GOOGLE_GENAI_API_KEY: ${{ secrets.GOOGLE_GENAI_API_KEY }}
         run: npm run test -- -j=12
 
       - name: Upload CTRF report

--- a/README.md
+++ b/README.md
@@ -723,7 +723,7 @@ Create a `.env` file with your API keys:
 ```bash
 OPENAI_API_KEY=sk-...
 ANTHROPIC_API_KEY=sk-ant-...
-GOOGLE_API_KEY=...
+GOOGLE_GENAI_API_KEY=...
 ```
 
 ## Debugging
@@ -785,7 +785,7 @@ jobs:
           platform: python # or 'node', or leave empty for both
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-          google-api-key: ${{ secrets.GOOGLE_API_KEY }}
+          google-genai-api-key: ${{ secrets.GOOGLE_GENAI_API_KEY }}
 ```
 
 ### Action Inputs
@@ -800,9 +800,7 @@ jobs:
 | `sentry-javascript-path` | No       | `""`          | Path to local sentry-javascript for linking                                                   |
 | `openai-api-key`         | Yes      | -             | OpenAI API key                                                                                |
 | `anthropic-api-key`      | Yes      | -             | Anthropic API key                                                                             |
-| `google-api-key`         | Yes      | -             | Google API key for GenAI                                                                      |
-| `google-vertex-project`  | No       | `""`          | Google Vertex AI project ID                                                                   |
-| `google-vertex-location` | No       | `us-central1` | Google Vertex AI location                                                                     |
+| `google-genai-api-key`   | Yes      | -             | Google GenAI API key                                                                          |
 
 ### Action Outputs
 
@@ -827,7 +825,7 @@ jobs:
     sentry-python-path: ${{ github.workspace }}
     openai-api-key: ${{ secrets.OPENAI_API_KEY }}
     anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-    google-api-key: ${{ secrets.GOOGLE_API_KEY }}
+    google-genai-api-key: ${{ secrets.GOOGLE_GENAI_API_KEY }}
 
 - name: Check results
   run: |

--- a/action.yml
+++ b/action.yml
@@ -45,17 +45,9 @@ inputs:
   anthropic-api-key:
     description: "Anthropic API key"
     required: true
-  google-api-key:
-    description: "Google API key for GenAI"
+  google-genai-api-key:
+    description: "Google GenAI API key"
     required: true
-  google-vertex-project:
-    description: "Google Vertex AI project ID"
-    required: false
-    default: ""
-  google-vertex-location:
-    description: "Google Vertex AI location"
-    required: false
-    default: "us-central1"
 
 outputs:
   success:
@@ -109,9 +101,7 @@ runs:
       env:
         OPENAI_API_KEY: ${{ inputs.openai-api-key }}
         ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
-        GOOGLE_API_KEY: ${{ inputs.google-api-key }}
-        GOOGLE_VERTEX_PROJECT: ${{ inputs.google-vertex-project }}
-        GOOGLE_VERTEX_LOCATION: ${{ inputs.google-vertex-location }}
+        GOOGLE_GENAI_API_KEY: ${{ inputs.google-genai-api-key }}
       run: |
         set +e
 

--- a/src/runner/browser-runner.ts
+++ b/src/runner/browser-runner.ts
@@ -302,7 +302,7 @@ export default defineConfig({
         window.RUN_ID = ${JSON.stringify(runId)};
         window.OPENAI_API_KEY = ${JSON.stringify(process.env.OPENAI_API_KEY || "")};
         window.ANTHROPIC_API_KEY = ${JSON.stringify(process.env.ANTHROPIC_API_KEY || "")};
-        window.GOOGLE_GENAI_API_KEY = ${JSON.stringify(process.env.GOOGLE_GENAI_API_KEY || process.env.GOOGLE_API_KEY || "")};
+        window.GOOGLE_GENAI_API_KEY = ${JSON.stringify(process.env.GOOGLE_GENAI_API_KEY || "")};
         window.testComplete = false;
       `);
 

--- a/src/runner/javascript-runner.ts
+++ b/src/runner/javascript-runner.ts
@@ -172,12 +172,7 @@ export class JavaScriptRunner {
       RUN_ID: runId,
       OPENAI_API_KEY: process.env.OPENAI_API_KEY || "",
       ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY || "",
-      GOOGLE_API_KEY: process.env.GOOGLE_API_KEY || "",
       GOOGLE_GENAI_API_KEY: process.env.GOOGLE_GENAI_API_KEY || "",
-      GOOGLE_APPLICATION_CREDENTIALS:
-        process.env.GOOGLE_APPLICATION_CREDENTIALS || "",
-      GOOGLE_VERTEX_PROJECT: process.env.GOOGLE_VERTEX_PROJECT || "",
-      GOOGLE_VERTEX_LOCATION: process.env.GOOGLE_VERTEX_LOCATION || "",
     };
 
     try {

--- a/src/runner/php-runner.ts
+++ b/src/runner/php-runner.ts
@@ -285,7 +285,7 @@ return [
       RUN_ID: runId,
       OPENAI_API_KEY: process.env.OPENAI_API_KEY || "",
       ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY || "",
-      GOOGLE_API_KEY: process.env.GOOGLE_API_KEY || "",
+      GOOGLE_GENAI_API_KEY: process.env.GOOGLE_GENAI_API_KEY || "",
     };
 
     try {

--- a/src/runner/python-runner.ts
+++ b/src/runner/python-runner.ts
@@ -268,7 +268,7 @@ ${dependencies.map(d => `    ${d},`).join('\n')}
       RUN_ID: runId,
       OPENAI_API_KEY: process.env.OPENAI_API_KEY || '',
       ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY || '',
-      GOOGLE_API_KEY: process.env.GOOGLE_API_KEY || '',
+      GOOGLE_GENAI_API_KEY: process.env.GOOGLE_GENAI_API_KEY || '',
     };
 
     try {

--- a/src/runner/templates/agents/python/google-genai/template.njk
+++ b/src/runner/templates/agents/python/google-genai/template.njk
@@ -3,16 +3,13 @@
 {% block imports %}
 {{ super() }}
 from google import genai
-from google.genai.types import HttpOptions, Tool, FunctionDeclaration
+from google.genai.types import Tool, FunctionDeclaration
 {% endblock %}
 
 {% block setup %}
 # Initialize Google GenAI client
 client = genai.Client(
-    vertexai=True,
-    project=os.environ["GOOGLE_VERTEX_PROJECT"],
-    location=os.environ["GOOGLE_VERTEX_LOCATION"],
-    http_options=HttpOptions(api_version="v1"),
+    api_key=os.environ["GOOGLE_GENAI_API_KEY"],
 )
 
 {% if agent and agent.tools and agent.tools | length > 0 %}

--- a/src/runner/templates/llm/node/google-genai/template.njk
+++ b/src/runner/templates/llm/node/google-genai/template.njk
@@ -26,9 +26,7 @@ let client;
       // Dynamic import of google-genai AFTER Sentry.init() to ensure instrumentation
       const { GoogleGenAI } = await import("@google/genai");
       client = new GoogleGenAI({
-        vertexai: true,
-        project: process.env.GOOGLE_VERTEX_PROJECT,
-        location: process.env.GOOGLE_VERTEX_LOCATION,
+        apiKey: process.env.GOOGLE_GENAI_API_KEY,
       });
 {% endblock %}
 


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/TET-1987/fix-usage-of-google-genai-api-keys