### PR TITLE
fix: Add stream_options to OpenAI Node streaming template for token usage …

### DIFF
--- a/src/runner/templates/llm/node/openai/template.njk
+++ b/src/runner/templates/llm/node/openai/template.njk
@@ -42,6 +42,7 @@ let client;
 {% endfor %}
           ],
           stream: true,
+          stream_options: { include_usage: true },
         });
 
         const chunks = [];


### PR DESCRIPTION
This adds stream_options: { include_usage: true } to the OpenAI Node streaming template so that token usage is included in the final streamed chunk, allowing Sentry's instrumentation to capture it correctly.

Documented in https://github.com/getsentry/sentry-docs/pull/16541 