### PR TITLE
fix: Update Google GenAI tests model

### DIFF
--- a/src/runner/templates/agents/python/google-genai/config.json
+++ b/src/runner/templates/agents/python/google-genai/config.json
@@ -13,7 +13,7 @@
   "versions": ["1.61.0"],
   "sentryVersions": ["2.51.0", "latest"],
   "modelOverrides": {
-    "request": "gemini-2.5-flash",
-    "response": "gemini-2.5-flash*"
+    "request": "gemini-2.5-flash-lite",
+    "response": "gemini-2.5-flash-lite*"
   }
 }

--- a/src/runner/templates/llm/browser/google-genai/config.json
+++ b/src/runner/templates/llm/browser/google-genai/config.json
@@ -11,7 +11,7 @@
   "versions": ["1.38.0"],
   "sentryVersions": ["latest"],
   "modelOverrides": {
-    "request": "gemini-2.5-flash",
-    "response": "gemini-2.5-flash*"
+    "request": "gemini-2.5-flash-lite",
+    "response": "gemini-2.5-flash-lite*"
   }
 }

--- a/src/runner/templates/llm/node/google-genai/config.json
+++ b/src/runner/templates/llm/node/google-genai/config.json
@@ -13,7 +13,7 @@
   "versions": ["1.38.0"],
   "sentryVersions": ["10.38.0", "latest"],
   "modelOverrides": {
-    "request": "gemini-2.5-flash",
-    "response": "gemini-2.5-flash*"
+    "request": "gemini-2.5-flash-lite",
+    "response": "gemini-2.5-flash-lite*"
   }
 }


### PR DESCRIPTION
The model gemini-2.0-flash has been marked deprecated by google; causing some errors in spans. This PR updates model used to gemini-2.5-flash