### PR TITLE
fix: Fix tests templates for Google GenAI 

### DIFF
--- a/src/runner/templates/llm/node/google-genai/template.njk
+++ b/src/runner/templates/llm/node/google-genai/template.njk
@@ -1,19 +1,19 @@
 {% extends "base.node.njk" %}
 
-{# Macro to render contents for Google GenAI - handles both string and multimodal array #}
-{% macro renderContents(content) %}
+{# Macro to render parts array for Google GenAI - returns a [...] array #}
+{% macro renderParts(content) %}
 {% if content is string %}
-"{{ content }}"
+[{ text: "{{ content }}" }]
 {%- elif content is iterable %}
 [
 {% for part in content %}
 {% if part.type == 'text' %}
-            { text: "{{ part.text }}" },
+              { text: "{{ part.text }}" },
 {% elif part.type == 'image' %}
-            { inlineData: { mimeType: "{{ part.mediaType }}", data: "{{ part.base64 }}" } },
+              { inlineData: { mimeType: "{{ part.mediaType }}", data: "{{ part.base64 }}" } },
 {% endif %}
 {% endfor %}
-          ]
+            ]
 {%- endif %}
 {% endmacro %}
 
@@ -32,19 +32,29 @@ let client;
 
 {% block test %}
 {% for input in inputs %}
-{% set system_content = "" %}
-{% set user_content = null %}
-{% for message in input.messages %}
-{% if message.role == 'system' %}{% set system_content = message.content %}{% endif %}
-{% if message.role == 'user' %}{% set user_content = message.content %}{% endif %}
-{% endfor %}
       // Request {{ loop.index }}{% if loop.length > 1 %} of {{ loop.length }}{% endif %}
 
       try {
+{% set system_content = "" %}
+{% set non_system_messages = [] %}
+{% for message in input.messages %}
+{% if message.role == 'system' %}
+{% set system_content = message.content %}
+{% else %}
+{% set _ = non_system_messages.push(message) %}
+{% endif %}
+{% endfor %}
+
+        const contents = [
+{% for message in non_system_messages %}
+          { role: "{% if message.role == 'assistant' %}model{% else %}{{ message.role }}{% endif %}", parts: {{ renderParts(message.content) }} },
+{% endfor %}
+        ];
+
 {% if isStreaming %}
         const stream = await client.models.generateContentStream({
           model: {% if causeAPIError %}"invalid-model"{% else %}"{{ input.model }}"{% endif %},
-          contents: {{ renderContents(user_content) }},
+          contents: contents,
 {% if system_content %}
           config: { systemInstruction: ["{{ system_content }}"] },
 {% endif %}
@@ -60,7 +70,7 @@ let client;
 {% else %}
         const response = await client.models.generateContent({
           model: {% if causeAPIError %}"invalid-model"{% else %}"{{ input.model }}"{% endif %},
-          contents: {{ renderContents(user_content) }},
+          contents: contents,
 {% if system_content %}
           config: { systemInstruction: ["{{ system_content }}"] },
 {% endif %}

--- a/src/test-cases/checks.ts
+++ b/src/test-cases/checks.ts
@@ -1159,8 +1159,8 @@ export const checkMessageTrimming: Check = {
             ? result.value
             : JSON.stringify(result.value);
 
-        if (messageStr.length >= maxExpectedSize) {
-          const msg = `Message should be trimmed (length ${messageStr.length} >= ${maxExpectedSize})`;
+        if (messageStr.length > maxExpectedSize) {
+          const msg = `Message should be trimmed (length ${messageStr.length} > ${maxExpectedSize})`;
           errors.push(msg);
           locations.push({
             spanId: span.span_id,


### PR DESCRIPTION
This PR introduces some fixes for Google GenAI tests templates: 

1. Fix Google GenAI Node template for multi-turn conversations
The template previously only sent the last user message as contents, discarding the full conversation history. This meant multi-turn tests had no context between turns (the model couldn't reference previous messages). Now builds a proper contents array from all non-system messages, mapping assistant role to model per Google's API convention.

2. Fix Google GenAI Node template for multimodal (vision) content
The template generated a nested array for parts when content was multimodal (text + image), producing parts: [[...]] instead of parts: [...]. This caused a 400 INVALID_ARGUMENT error from Google's API, preventing the vision test from running at all.

3. A message of exactly the max size doesn't need further trimming — only messages exceeding the threshold should fail the check.