### PR TITLE
fix(pydantic-ai): Add agent name to Agent constructor in template

### DIFF
--- a/src/runner/templates/agents/python/pydantic-ai/template.njk
+++ b/src/runner/templates/agents/python/pydantic-ai/template.njk
@@ -18,6 +18,7 @@ from pydantic_ai import Agent, ImageUrl, RunContext
 agent = Agent(
     "openai:{{ inputs[0].model }}",
     system_prompt="{{ system_content }}",
+    name="{{ agent.name }}"
 )
 
 {% if agent.tools | length > 0 %}


### PR DESCRIPTION
Pass the agent name from the test definition to the Pydantic AI `Agent` constructor so the Sentry SDK can capture `gen_ai.agent.name` on spans.

Without this, the `name` parameter is omitted from the constructed agent, meaning pydantic-ai tests would fail `checkAgentSpanAttributes` and `checkAgentHierarchy` — both of which require `gen_ai.agent.name` to be present and correctly propagated to child spans.

Fixes the "Basic Agent Test" errors

Fixes PY-2114