### PR TITLE
ref: Remove gen_ai.tool.type assertions from test framework

### DIFF
--- a/src/runner/templates/agents/node/manual/template.njk
+++ b/src/runner/templates/agents/node/manual/template.njk
@@ -186,7 +186,6 @@ const TOOLS = {{ agent.tools | dump }};
           toolSpan.setAttribute("gen_ai.operation.name", "execute_tool");
           toolSpan.setAttribute("gen_ai.agent.name", AGENT_NAME);
           toolSpan.setAttribute("gen_ai.tool.name", "{{ tool.name }}");
-          toolSpan.setAttribute("gen_ai.tool.type", "function");
           toolSpan.setAttribute("gen_ai.tool.description", "{{ tool.description }}");
 
           const toolInputJson{{ turnIndex }}_{{ loop.index }} = JSON.stringify({{ tool.arguments | dump }});

--- a/src/runner/templates/agents/python/manual/template.njk
+++ b/src/runner/templates/agents/python/manual/template.njk
@@ -183,7 +183,6 @@ TOOLS = {{ agent.tools | dump }}
             tool_span.set_data("gen_ai.operation.name", "execute_tool")
             tool_span.set_data("gen_ai.agent.name", AGENT_NAME)
             tool_span.set_data("gen_ai.tool.name", "{{ tool.name }}")
-            tool_span.set_data("gen_ai.tool.type", "function")
             tool_span.set_data("gen_ai.tool.description", "{{ tool.description }}")
 
             tool_input_json = json.dumps({{ tool.arguments | dump }})

--- a/src/test-cases/agents/tool-call.ts
+++ b/src/test-cases/agents/tool-call.ts
@@ -107,14 +107,12 @@ export const toolCallAgentTest: TestDefinition = {
     checkToolCalls([
       {
         name: "add",
-        type: "function",
         description: "Add two numbers together",
         input: { a: 3, b: 5 },
         output: 8,
       },
       {
         name: "multiply",
-        type: "function",
         description: "Multiply two numbers together",
         input: { a: 8, b: 4 },
         output: 32,

--- a/src/test-cases/checks.ts
+++ b/src/test-cases/checks.ts
@@ -225,7 +225,6 @@ export const checkAgentSpanAttributes: Check = {
  * Validates:
  * - description equals "<gen_ai.operation.name> <gen_ai.tool.name>"
  * - gen_ai.operation.name matches TOOL_OPERATION_NAME_PATTERN
- * - gen_ai.tool.type exists
  * - gen_ai.tool.name exists
  * - gen_ai.tool.description exists
  *
@@ -243,7 +242,6 @@ export const checkToolSpanAttributes: Check = {
       "description": (span) =>
         `${span.data?.["gen_ai.operation.name"]} ${span.data?.["gen_ai.tool.name"]}`,
       "gen_ai.operation.name": TOOL_OPERATION_NAME_PATTERN,
-      "gen_ai.tool.type": true,
       "gen_ai.tool.name": true,
       "gen_ai.tool.description": true,
     });
@@ -256,8 +254,6 @@ export const checkToolSpanAttributes: Check = {
 export interface ExpectedToolCall {
   /** Tool name to match */
   name: string;
-  /** Expected tool type (e.g., "function") */
-  type?: string;
   /** Expected tool description */
   description?: string;
   /** Expected input arguments (parsed from gen_ai.tool.input JSON) */
@@ -276,7 +272,6 @@ export interface ExpectedToolCall {
  * // Check a single tool call
  * checkToolCalls([{
  *   name: "add",
- *   type: "function",
  *   description: "Add two numbers together",
  *   input: { a: 4, b: 7 },
  *   output: 11,
@@ -315,16 +310,6 @@ export function checkToolCalls(expectedTools: ExpectedToolCall[]): Check {
         if (!toolSpan) {
           errors.push(`Should have a tool span for "${expectedToolName}" (mapped from "${expected.name}")`);
           continue;
-        }
-
-        // Validate type if specified
-        if (expected.type !== undefined) {
-          const actual = toolSpan.data?.["gen_ai.tool.type"];
-          if (actual !== expected.type) {
-            const msg = `Tool "${expected.name}" should have type "${expected.type}" but has "${actual}"`;
-            errors.push(msg);
-            locations.push({ spanId: toolSpan.span_id, attribute: "gen_ai.tool.type", message: msg });
-          }
         }
 
         // Validate description if specified


### PR DESCRIPTION
Remove all references to the `gen_ai.tool.type` attribute from the testing framework.

This attribute is no longer part of the span conventions, so assertions on it
should be removed to avoid false failures as SDKs stop emitting it.

Changes:
- Remove `gen_ai.tool.type` from `checkToolSpanAttributes` assertion
- Remove `type` field from `ExpectedToolCall` interface and `checkToolCalls` validation
- Remove `type: "function"` from tool-call test expectations
- Remove `gen_ai.tool.type` setAttribute/set_data from manual agent templates (node + python)

Fixes PY-2284