### PR TITLE
fix: Support 'args' key in response tool call argument extraction

### DIFF
--- a/src/test-cases/checks.ts
+++ b/src/test-cases/checks.ts
@@ -875,6 +875,7 @@ export function checkResponseToolCalls(
         let actualArgs: Record<string, unknown>;
         const argsRaw =
           foundCall.arguments ||
+          foundCall.args ||
           (foundCall.function as Record<string, unknown>)?.arguments;
 
         if (typeof argsRaw === "string") {


### PR DESCRIPTION
Add `foundCall.args` as a fallback when extracting arguments from tool
call response data in `checkResponseToolCalls`.

Some frameworks (e.g. LangGraph Python) return tool calls with an `args`
key rather than `arguments`:

```json
{"name": "read_file", "args": {"path": "/nonexistent/file.txt"}, "id": "call_...", "type": "tool_call"}
```

The lookup chain is now: `arguments` → `args` → `function.arguments`.

Fixes PY-2281