### PR TITLE
fix: Use `instrumentCreateReactAgent` in LangGraph cloudflare template

### DIFF
--- a/src/runner/templates/agents/cloudflare/langgraph/template.njk
+++ b/src/runner/templates/agents/cloudflare/langgraph/template.njk
@@ -74,8 +74,8 @@ import { z } from "zod";
         openAIApiKey: env.OPENAI_API_KEY,
       });
 {% endif %}
-      const agent = createReactAgent({ llm, tools: {% if agent and agent.tools and agent.tools.length > 0 %}tools{% else %}[]{% endif %}, name: "{{ agent.name }}" });
-      Sentry.instrumentLangGraph(agent, { recordInputs: true, recordOutputs: true });
+      const instrumentedCreateReactAgent = Sentry.instrumentCreateReactAgent(createReactAgent, { recordInputs: true, recordOutputs: true });
+      const agent = instrumentedCreateReactAgent({ llm, tools: {% if agent and agent.tools and agent.tools.length > 0 %}tools{% else %}[]{% endif %}, name: "{{ agent.name }}" });
 {% endblock %}
 
 {% block test %}


### PR DESCRIPTION
This PR updates the cloudflare LangGraph template to use the newly released `instrumentCreateReactAgent` function (released with [10.51.0](https://github.com/getsentry/sentry-javascript/releases/tag/10.51.0)).