### PR TITLE
feat(python): enable stream_gen_ai_spans in Python test templates

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,8 +43,8 @@ Options:
   --sentry-javascript <path> Use local Sentry JavaScript SDK (link)
   --sentry-php <path>        Use local Sentry PHP SDK (core sentry/sentry-php)
   --sentry-laravel <path>    Use local Sentry Laravel SDK (composer path repository)
-  --stream-gen-ai-spans      Enable streamGenAiSpans in JS Sentry.init() (default: on)
-  --not-stream-gen-ai-spans  Disable streamGenAiSpans in JS Sentry.init()
+  --stream-gen-ai-spans      Enable streamGenAiSpans / stream_gen_ai_spans in Sentry.init() (default: on)
+  --not-stream-gen-ai-spans  Disable streamGenAiSpans / stream_gen_ai_spans in Sentry.init()
   --help, -h                 Show this help message
 
 Examples:

--- a/src/runner/runner.ts
+++ b/src/runner/runner.ts
@@ -271,7 +271,7 @@ export class Runner {
       ...(testDefinition.agent && { agent: testDefinition.agent }),
       ...(testDefinition.mcpServer && { mcpServer: testDefinition.mcpServer }),
       inputs: processedInputs,
-      streamGenAiSpans: context.streamGenAiSpans !== false, // JS Sentry.init() flag, default true
+      streamGenAiSpans: context.streamGenAiSpans !== false, // Sentry.init() flag (JS + Python), default true
     };
 
     // PHP/Laravel: add computed class names and command signature for templates

--- a/src/runner/templates/base.python.njk
+++ b/src/runner/templates/base.python.njk
@@ -23,6 +23,7 @@ sentry_sdk.init(
     dsn=os.environ.get("SENTRY_DSN"),
     traces_sample_rate=1.0,
     send_default_pii=True,
+    stream_gen_ai_spans={{ "True" if streamGenAiSpans else "False" }},
 )
 {% endblock %}
 

--- a/src/runner/templates/embeddings/python/litellm/template.njk
+++ b/src/runner/templates/embeddings/python/litellm/template.njk
@@ -12,6 +12,7 @@ sentry_sdk.init(
     dsn=os.environ.get("SENTRY_DSN"),
     traces_sample_rate=1.0,
     send_default_pii=True,
+    stream_gen_ai_spans={{ "True" if streamGenAiSpans else "False" }},
     integrations=[LiteLLMIntegration(include_prompts=True)],
     disabled_integrations=[OpenAIIntegration()],
 )

--- a/src/runner/templates/llm/python/litellm/template.njk
+++ b/src/runner/templates/llm/python/litellm/template.njk
@@ -86,6 +86,7 @@ sentry_sdk.init(
     dsn=os.environ.get("SENTRY_DSN"),
     traces_sample_rate=1.0,
     send_default_pii=True,
+    stream_gen_ai_spans={{ "True" if streamGenAiSpans else "False" }},
     integrations=[LiteLLMIntegration(include_prompts=True)],
     disabled_integrations=[OpenAIIntegration()],
 )

--- a/src/runner/templates/mcp/python/mcp/template.njk
+++ b/src/runner/templates/mcp/python/mcp/template.njk
@@ -48,6 +48,7 @@ sentry_sdk.init(
     dsn=os.environ.get("SENTRY_DSN"),
     traces_sample_rate=1.0,
     send_default_pii=True,
+    stream_gen_ai_spans={{ "True" if streamGenAiSpans else "False" }},
     integrations=[MCPIntegration()],
 )
 {% endblock %}

--- a/src/span-collector/server.ts
+++ b/src/span-collector/server.ts
@@ -152,8 +152,9 @@ export class SpanCollector {
 
         // v2 span envelope: application/vnd.sentry.items.span.v2+json
         // Body shape: { version: 2, items: [<v2span>, ...] }
-        // Used by Sentry JS SDK 10.53.0+ when streamGenAiSpans is enabled —
-        // gen_ai spans are stripped from the transaction and shipped here.
+        // Used by Sentry JS SDK 10.53.0+ and Python SDK 2.60.0+ when
+        // streamGenAiSpans / stream_gen_ai_spans is enabled — gen_ai spans
+        // are stripped from the transaction and shipped here.
         // Spec: https://develop.sentry.dev/sdk/telemetry/spans/span-protocol
         if (
           itemHeader.type === 'span' &&

--- a/src/types.ts
+++ b/src/types.ts
@@ -311,6 +311,6 @@ export interface RunnerContext {
   timeoutMs: number;
   // Controls whether to print verbose console output (default: true)
   verbose?: boolean;
-  // JS only: value to pass for `streamGenAiSpans` in Sentry.init() (default: true)
+  // Value to pass for `streamGenAiSpans` (JS) / `stream_gen_ai_spans` (Python) in Sentry.init() (default: true)
   streamGenAiSpans?: boolean;
 }


### PR DESCRIPTION
Pass the existing `streamGenAiSpans` flag through to the Python base template as `stream_gen_ai_spans` in `sentry_sdk.init()`. This enables span streaming for `gen_ai.*` spans in Python SDK 2.60.0+, matching the behavior already in place for the JS SDK.

The span collector already handles v2 span envelopes (`application/vnd.sentry.items.span.v2+json`), so no changes are needed there — only the template and documentation comments are updated to reflect cross-platform support.

### Changes

- **`base.python.njk`** — Added `stream_gen_ai_spans=True/False` to `sentry_sdk.init()`
- **`cli.ts`** — Updated help text to reflect the flag applies to both JS and Python
- **`runner.ts`** / **`types.ts`** / **`server.ts`** — Updated comments

Refs TET-2360