### PR TITLE
fix(ci): split Playwright install to prevent hang on GitHub Actions

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -99,8 +99,16 @@ jobs:
           npm ci
           npm run build
 
-      - name: Install Playwright browsers (for browser platform only)
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright system dependencies
+        run: npx playwright install-deps chromium
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          NEEDRESTART_MODE: a
+        timeout-minutes: 5
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium
+        timeout-minutes: 5
 
       - name: Run tests
         continue-on-error: true

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -92,8 +92,16 @@ jobs:
           npm ci
           npm run build
 
-      - name: Install Playwright browsers (for browser platform only)
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright system dependencies
+        run: npx playwright install-deps chromium
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          NEEDRESTART_MODE: a
+        timeout-minutes: 5
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium
+        timeout-minutes: 5
 
       - name: Run tests
         id: run-tests
@@ -193,8 +201,16 @@ jobs:
           npm ci
           npm run build
 
-      - name: Install Playwright browsers (for browser platform only)
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright system dependencies
+        run: npx playwright install-deps chromium
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          NEEDRESTART_MODE: a
+        timeout-minutes: 5
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium
+        timeout-minutes: 5
 
       - name: Run tests
         id: run-tests


### PR DESCRIPTION
## Problem

The daily test run has been broken since May 29 — every run times out at the 6-hour GitHub Actions job limit. All 18 consecutive daily runs have failed.

**Root cause:** `npx playwright install --with-deps chromium` hangs indefinitely after the Chrome download completes (reaches 100% but never finishes extraction/setup). This started when the GitHub Actions runner image updated, likely causing an interaction issue between `--with-deps` system dependency installation (`needrestart`/`dpkg`) and the browser download process.

Ref: https://github.com/getsentry/testing-ai-sdk-integrations/actions/runs/27492154452

## Fix

Split the combined install into two separate steps:

1. **`npx playwright install-deps chromium`** — installs system dependencies only, with `DEBIAN_FRONTEND=noninteractive` and `NEEDRESTART_MODE=a` to prevent any interactive prompts
2. **`npx playwright install chromium`** — downloads and installs browser binaries

Both steps have a **5-minute timeout** as a safety net.

Applied to both `daily-tests.yml` and `pr-tests.yml` workflows.