### PR TITLE
fix(ci): bump Playwright to ^1.60.0 to fix install hang on Node 24.16+

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -99,16 +99,8 @@ jobs:
           npm ci
           npm run build
 
-      - name: Install Playwright system dependencies
-        run: npx playwright install-deps chromium
-        env:
-          DEBIAN_FRONTEND: noninteractive
-          NEEDRESTART_MODE: a
-        timeout-minutes: 5
-
       - name: Install Playwright browsers
-        run: npx playwright install chromium
-        timeout-minutes: 5
+        run: npx playwright install --with-deps chromium
 
       - name: Run tests
         continue-on-error: true

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -92,16 +92,8 @@ jobs:
           npm ci
           npm run build
 
-      - name: Install Playwright system dependencies
-        run: npx playwright install-deps chromium
-        env:
-          DEBIAN_FRONTEND: noninteractive
-          NEEDRESTART_MODE: a
-        timeout-minutes: 5
-
       - name: Install Playwright browsers
-        run: npx playwright install chromium
-        timeout-minutes: 5
+        run: npx playwright install --with-deps chromium
 
       - name: Run tests
         id: run-tests
@@ -201,16 +193,8 @@ jobs:
           npm ci
           npm run build
 
-      - name: Install Playwright system dependencies
-        run: npx playwright install-deps chromium
-        env:
-          DEBIAN_FRONTEND: noninteractive
-          NEEDRESTART_MODE: a
-        timeout-minutes: 5
-
       - name: Install Playwright browsers
-        run: npx playwright install chromium
-        timeout-minutes: 5
+        run: npx playwright install --with-deps chromium
 
       - name: Run tests
         id: run-tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "htm": "^3.1.1",
         "log-update": "^7.0.2",
         "nunjucks": "^3.2.4",
-        "playwright": "^1.49.1",
+        "playwright": "^1.60.0",
         "prettier": "^3.8.1",
         "vhtml": "^2.2.0",
         "vite": "^6.0.11",
@@ -849,6 +849,7 @@
       "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1299,6 +1300,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
       "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1564,6 +1566,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1572,12 +1575,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1590,9 +1593,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -1674,6 +1677,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "htm": "^3.1.1",
     "log-update": "^7.0.2",
     "nunjucks": "^3.2.4",
-    "playwright": "^1.49.1",
+    "playwright": "^1.60.0",
     "prettier": "^3.8.1",
     "vhtml": "^2.2.0",
     "vite": "^6.0.11",


### PR DESCRIPTION
## Problem

Every daily CI run has been failing since ~June 15 because `npx playwright install chromium` hangs after the browser download reaches 100%.

## Root Cause

Node 24.16.0 (now the default on `ubuntu-latest` runners) shipped a zlib regression ([nodejs/node#63487](https://github.com/nodejs/node/issues/63487)) that breaks the `extract-zip`/`yauzl` library stack used by Playwright < 1.60.0. The download completes but extraction hangs indefinitely.

Tracked upstream: [microsoft/playwright#41000](https://github.com/microsoft/playwright/issues/41000), [#40998](https://github.com/microsoft/playwright/issues/40998), [#41133](https://github.com/microsoft/playwright/issues/41133)

## Fix

- **Bump `playwright` from `^1.49.1` → `^1.60.0`** — Playwright 1.60.0 replaced the extraction codepath, sidestepping the Node bug
- **Revert split install workaround** — the previous fix (#152) split `install --with-deps` into two steps with timeouts, which didn't address the root cause. Reverted back to the simpler single command

## Why previous fixes didn't hold

- **Splitting install steps** (PR #152): didn't touch the extraction phase that actually hangs
- **Caching `~/.cache/ms-playwright`**: only masks the issue on cache hits; any cache miss → hang returns

Closes TET-2575